### PR TITLE
feat: add host.docker.internal support

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -317,6 +317,13 @@ describe('docker-manager', () => {
       expect(agent.dns_search).toEqual([]);
     });
 
+    it('should configure extra_hosts for host.docker.internal', () => {
+      const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+      const agent = result.services.agent;
+
+      expect(agent.extra_hosts).toEqual(['host.docker.internal:host-gateway']);
+    });
+
     it('should override environment variables with additionalEnv', () => {
       const originalEnv = process.env.GITHUB_TOKEN;
       process.env.GITHUB_TOKEN = 'original_token';

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -297,6 +297,7 @@ export function generateDockerCompose(
     },
     dns: dnsServers, // Use configured DNS servers (prevents DNS exfiltration)
     dns_search: [], // Disable DNS search domains to prevent embedded DNS fallback
+    extra_hosts: ['host.docker.internal:host-gateway'], // Enable host.docker.internal on Linux
     volumes: agentVolumes,
     environment,
     depends_on: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,10 +418,20 @@ export interface DockerService {
 
   /**
    * DNS search domains for the container
-   * 
+   *
    * Appended to unqualified hostnames during DNS resolution.
    */
   dns_search?: string[];
+
+  /**
+   * Extra hosts to add to /etc/hosts in the container
+   *
+   * Array of host:ip mappings. Used to enable host.docker.internal
+   * on Linux where it's not available by default.
+   *
+   * @example ['host.docker.internal:host-gateway']
+   */
+  extra_hosts?: string[];
 
   /**
    * Volume mount specifications


### PR DESCRIPTION
## Summary

- Enable `host.docker.internal` DNS name in the agent container for cross-platform container-to-host communication
- Add `extra_hosts: ['host.docker.internal:host-gateway']` to Docker Compose configuration
- Useful for connecting to MCP servers running on the host machine from inside the firewall

## Background

`host.docker.internal` is a special DNS name that resolves to the host machine's IP address from inside a container:

| Platform | Native Support |
|----------|----------------|
| Docker Desktop (macOS/Windows) | Built-in |
| Linux | Requires explicit `extra_hosts` config |

Previously, users on Linux had to use the gateway IP (`172.30.0.1`) directly. With this change, both approaches work:
- `http://host.docker.internal:8080/mcp/gh-aw`
- `http://172.30.0.1:8080/mcp/gh-aw`

## Changes

- `src/docker-manager.ts`: Add `extra_hosts` to agent service config
- `src/types.ts`: Add `extra_hosts` property to `DockerService` interface
- `src/docker-manager.test.ts`: Add test for `extra_hosts` configuration

## Test plan

- [x] Unit tests pass (`npm test -- --testPathPattern="docker-manager"`)
- [ ] Manual test: Run a server on host, connect from inside awf using `host.docker.internal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)