### PR TITLE
feat: add --enable-host-access flag and fix CONNECT to port 80

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -317,11 +317,44 @@ describe('docker-manager', () => {
       expect(agent.dns_search).toEqual([]);
     });
 
-    it('should configure extra_hosts for host.docker.internal', () => {
+    it('should NOT configure extra_hosts by default (opt-in for security)', () => {
       const result = generateDockerCompose(mockConfig, mockNetworkConfig);
       const agent = result.services.agent;
+      const squid = result.services['squid-proxy'];
 
-      expect(agent.extra_hosts).toEqual(['host.docker.internal:host-gateway']);
+      expect(agent.extra_hosts).toBeUndefined();
+      expect(squid.extra_hosts).toBeUndefined();
+    });
+
+    describe('enableHostAccess option', () => {
+      it('should configure extra_hosts when enableHostAccess is true', () => {
+        const config = { ...mockConfig, enableHostAccess: true };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const agent = result.services.agent;
+        const squid = result.services['squid-proxy'];
+
+        expect(agent.extra_hosts).toEqual(['host.docker.internal:host-gateway']);
+        expect(squid.extra_hosts).toEqual(['host.docker.internal:host-gateway']);
+      });
+
+      it('should NOT configure extra_hosts when enableHostAccess is false', () => {
+        const config = { ...mockConfig, enableHostAccess: false };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const agent = result.services.agent;
+        const squid = result.services['squid-proxy'];
+
+        expect(agent.extra_hosts).toBeUndefined();
+        expect(squid.extra_hosts).toBeUndefined();
+      });
+
+      it('should NOT configure extra_hosts when enableHostAccess is undefined', () => {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const agent = result.services.agent;
+        const squid = result.services['squid-proxy'];
+
+        expect(agent.extra_hosts).toBeUndefined();
+        expect(squid.extra_hosts).toBeUndefined();
+      });
     });
 
     it('should override environment variables with additionalEnv', () => {

--- a/src/squid-config.ts
+++ b/src/squid-config.ts
@@ -309,7 +309,11 @@ acl CONNECT method CONNECT
 # Access rules
 # Deny unsafe ports first
 http_access deny !Safe_ports
-http_access deny CONNECT !SSL_ports
+# Allow CONNECT to Safe_ports (80 and 443) instead of just SSL_ports (443)
+# This is required because some HTTP clients (e.g., Node.js fetch) use CONNECT
+# method even for HTTP connections when going through a proxy.
+# See: gh-aw-firewall issue #189
+http_access deny CONNECT !Safe_ports
 
 ${accessRulesSection}# Deny requests to unknown domains (not in allow-list)
 # This applies to all sources including localnet

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,27 @@ export interface WrapperConfig {
    * @example '/tmp/my-proxy-logs'
    */
   proxyLogsDir?: string;
+
+  /**
+   * Enable access to host services via host.docker.internal
+   *
+   * When true, adds `host.docker.internal` hostname resolution to containers,
+   * allowing traffic to reach services running on the host machine.
+   *
+   * **Security Warning**: When enabled and `host.docker.internal` is added to
+   * --allow-domains, containers can access ANY service running on the host,
+   * including databases, APIs, and other sensitive services. Only enable this
+   * when you specifically need container-to-host communication (e.g., for MCP
+   * gateways running on the host).
+   *
+   * @default false
+   * @example
+   * ```bash
+   * # Enable host access for MCP gateway on host
+   * awf --enable-host-access --allow-domains host.docker.internal -- curl http://host.docker.internal:8080
+   * ```
+   */
+  enableHostAccess?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR addresses issue #189 by:

- **Making `host.docker.internal` opt-in via `--enable-host-access` flag**
  - By default, containers cannot resolve `host.docker.internal`
  - When enabled, adds `extra_hosts` to both Squid and agent containers
  - Shows security warning when combined with `host.docker.internal` domain

- **Allowing CONNECT method to Safe_ports (80 and 443)**
  - Changes `http_access deny CONNECT !SSL_ports` to `!Safe_ports`
  - Required because Node.js fetch uses CONNECT for HTTP through proxy
  - Domain ACLs remain the primary security control

## Security Considerations

1. **Host access is opt-in** - Prevents accidental exposure of host services
2. **Warning displayed** when `host.docker.internal` is in allowed domains
3. **Safe_ports change has minimal security impact** - Domain filtering remains the primary control

## Usage

```bash
# Enable access to services running on the host via host.docker.internal
sudo awf \
  --enable-host-access \
  --allow-domains host.docker.internal \
  -- curl http://host.docker.internal:8080
```

## Test Plan

- [x] Unit tests for `--enable-host-access` flag behavior
- [x] Unit tests for Safe_ports CONNECT rule
- [x] Documentation updated in `docs/usage.md`
- [ ] Manual testing with MCP gateway on host

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)