### PR TITLE
docs: add egress filtering documentation

### DIFF
--- a/docs/egress-filtering.md
+++ b/docs/egress-filtering.md
@@ -1,4 +1,4 @@
-# Security Model: Port Restrictions vs Domain Allowlist
+# Egress Filtering: Port Restrictions vs Domain Allowlist
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

Adds `docs/egress-filtering.md` explaining AWF's security model for network filtering, specifically addressing: **Why use port restrictions if they can be bypassed?**

Key points:
- Domain allowlist is the primary security control
- Port restrictions are defense-in-depth, not primary security
- Includes literature citations from industry sources

## Literature Cited

**Supporting domain allowlist as primary control:**
- [Squid Wiki - HTTPS](https://wiki.squid-cache.org/Features/HTTPS) - "Anything that uses a two-way TCP connection can be passed through a CONNECT tunnel"
- [Palo Alto Networks NGFW](https://www.paloaltonetworks.co.uk/cyberpedia/what-is-a-next-generation-firewall-ngfw) - "Port-based filtering largely ineffective"

**Supporting port restrictions as defense-in-depth:**
- [Squid SecurityPitfalls](https://wiki.squid-cache.org/SquidFaq/SecurityPitfalls) - Official guidance on SSL_Ports ACL
- [CMU SEI Egress Filtering](https://www.sei.cmu.edu/blog/best-practices-and-considerations-in-egress-filtering/) - Real-world attack prevention examples
- [NIST SP 800-41](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-41r1.pdf) - Federal firewall guidance

## Test plan

- [x] Document renders correctly in markdown
- [x] All external links are valid and accessible

🤖 Generated with [Claude Code](https://claude.ai/code)