### PR TITLE
feat: add --agent-base-image act for pre-built GitHub Actions parity

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -238,6 +238,21 @@ describe('docker-manager', () => {
       expect(result.services.agent.build?.args?.BASE_IMAGE).toBe('ghcr.io/catthehacker/ubuntu:full-22.04@sha256:a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1');
     });
 
+    it('should use agent-act image when useAgentActImage is true', () => {
+      const actImageConfig = { ...mockConfig, useAgentActImage: true };
+      const result = generateDockerCompose(actImageConfig, mockNetworkConfig);
+
+      expect(result.services.agent.image).toBe('ghcr.io/githubnext/gh-aw-firewall/agent-act:latest');
+      expect(result.services.agent.build).toBeUndefined();
+    });
+
+    it('should use default agent image when useAgentActImage is false', () => {
+      const defaultConfig = { ...mockConfig, useAgentActImage: false };
+      const result = generateDockerCompose(defaultConfig, mockNetworkConfig);
+
+      expect(result.services.agent.image).toBe('ghcr.io/githubnext/gh-aw-firewall/agent:latest');
+    });
+
     it('should not pass BASE_IMAGE when agentBaseImage is explicitly set to default ubuntu:22.04', () => {
       const customBaseImageConfig = {
         ...mockConfig,

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -420,7 +420,9 @@ export function generateDockerCompose(
 
   // Use GHCR image or build locally
   if (useGHCR) {
-    agentService.image = `${registry}/agent:${tag}`;
+    // Use agent-act image if requested for GitHub Actions parity
+    const agentImageName = config.useAgentActImage ? 'agent-act' : 'agent';
+    agentService.image = `${registry}/${agentImageName}:${tag}`;
   } else {
     const buildArgs: Record<string, string> = {
       // Pass host UID/GID to match file ownership in container

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,19 +149,32 @@ export interface WrapperConfig {
 
   /**
    * Base image for the agent container when building locally
-   * 
+   *
    * Allows customization of the agent container base image for closer parity
    * with GitHub Actions runner environments. Only used when buildLocal is true.
-   * 
+   *
    * Options:
    * - 'ubuntu:22.04' (default): Minimal image, smallest size (~200MB)
    * - 'ghcr.io/catthehacker/ubuntu:runner-22.04': Closer to GitHub Actions runner (~2-5GB)
    * - 'ghcr.io/catthehacker/ubuntu:full-22.04': Near-identical to GitHub Actions runner (~20GB compressed)
-   * 
+   *
    * @default 'ubuntu:22.04'
    * @example 'ghcr.io/catthehacker/ubuntu:runner-22.04'
    */
   agentBaseImage?: string;
+
+  /**
+   * Use the pre-built agent-act image from GHCR for GitHub Actions parity
+   *
+   * When true, uses ghcr.io/githubnext/gh-aw-firewall/agent-act instead of
+   * the default agent image. This image is built with catthehacker/ubuntu:act-24.04
+   * as the base for better GitHub Actions runner compatibility.
+   *
+   * Set via --agent-base-image act
+   *
+   * @default false
+   */
+  useAgentActImage?: boolean;
 
   /**
    * Additional environment variables to pass to the agent execution container


### PR DESCRIPTION
## Summary

Add support for `--agent-base-image act` which uses the pre-built `agent-act` image from GHCR without requiring `--build-local`.

## Changes

- CLI accepts `act` as a special value for `--agent-base-image`
- When `act` is specified, uses `ghcr.io/githubnext/gh-aw-firewall/agent-act:latest`
- Custom images (e.g., `ghcr.io/catthehacker/ubuntu:runner-22.04`) still require `--build-local` (now errors instead of silently warning)
- Added `useAgentActImage` flag to `WrapperConfig`
- Updated `docker-manager` to select `agent-act` image when flag is set
- Added tests for new functionality

## Usage

```bash
# Use pre-built agent-act image with GitHub Actions parity
awf --agent-base-image act --allow-domains github.com -- your-command

# Still works: default minimal image
awf --allow-domains github.com -- your-command

# Still works: custom image with --build-local (requires source checkout)
awf --build-local --agent-base-image ghcr.io/catthehacker/ubuntu:runner-22.04 \
  --allow-domains github.com -- your-command
```

## Test plan

- [x] Unit tests for `useAgentActImage` in docker-manager
- [ ] Manual test: `awf --agent-base-image act --allow-domains github.com -- curl https://github.com`
- [ ] Verify error when using custom image without `--build-local`

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)