### PR TITLE
chore: complete migration from githubnext to github organization

### DIFF
--- a/.github/workflows/pelis-agent-factory-advisor.md
+++ b/.github/workflows/pelis-agent-factory-advisor.md
@@ -22,7 +22,7 @@ tools:
 network:
   allowed:
     - github
-    - "githubnext.github.io"
+    - "github.github.io"
 safe-outputs:
   create-discussion:
     title-prefix: "[Pelis Agent Factory Advisor] "

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A network firewall for agentic workflows with domain whitelisting. This tool provides L7 (HTTP/HTTPS) egress control using [Squid proxy](https://www.squid-cache.org/) and Docker containers, restricting network access to a whitelist of approved domains for AI agents and their MCP servers.
 
 > [!TIP]
-> This project is a part of GitHub Next's explorations of [Agentic Workflows](https://github.com/github/gh-aw). For more background, check out the [project page on the GitHub Next website](https://githubnext.com/projects/agentic-workflows/)! ✨
+> This project is a part of GitHub's explorations of [Agentic Workflows](https://github.com/github/gh-aw). For more background, check out the [project page](https://github.github.io/gh-aw/)! ✨
 
 ## What it does
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -4,7 +4,7 @@ import mermaid from 'astro-mermaid';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://githubnext.github.io',
+	site: 'https://github.github.io',
 	base: '/gh-aw-firewall',
 	integrations: [
 		mermaid(),
@@ -12,10 +12,10 @@ export default defineConfig({
 			title: 'Agentic Workflow Firewall',
 			description: 'Network firewall for agentic workflows with domain whitelisting',
 			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/githubnext/gh-aw-firewall' },
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/github/gh-aw-firewall' },
 			],
 			editLink: {
-				baseUrl: 'https://github.com/githubnext/gh-aw-firewall/edit/main/docs-site/',
+				baseUrl: 'https://github.com/github/gh-aw-firewall/edit/main/docs-site/',
 			},
 			logo: {
 				src: './src/assets/logo.svg',

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -6,7 +6,7 @@ description: Network firewall for AI agents with domain whitelisting - control e
 A network firewall designed specifically for AI agents and agentic workflows. Control which domains your AI agents can access while maintaining full filesystem access in a containerized environment.
 
 :::tip[Part of GitHub Next]
-This project is part of GitHub Next's explorations of [Agentic Workflows](https://github.com/github/gh-aw). Learn more on the [GitHub Next website](https://githubnext.com/projects/agentic-workflows/)! ✨
+This project is part of GitHub's explorations of [Agentic Workflows](https://github.com/github/gh-aw). Learn more on the [project page](https://github.github.io/gh-aw/)! ✨
 :::
 
 ## What Is This?

--- a/docs-site/src/content/docs/reference/cli-reference.md
+++ b/docs-site/src/content/docs/reference/cli-reference.md
@@ -106,7 +106,7 @@ Path to file with blocked domains. Supports the same format as `--allow-domains-
 Enable SSL Bump for HTTPS content inspection. When enabled, the firewall generates a per-session CA certificate and intercepts HTTPS connections, allowing URL path filtering.
 
 ```bash
---ssl-bump --allow-urls "https://github.com/githubnext/*"
+--ssl-bump --allow-urls "https://github.com/myorg/*"
 ```
 
 :::caution[HTTPS Interception]
@@ -127,7 +127,7 @@ Comma-separated list of allowed URL patterns for HTTPS traffic. Requires `--ssl-
 
 ```bash
 # Single pattern
---allow-urls "https://github.com/githubnext/*"
+--allow-urls "https://github.com/myorg/*"
 
 # Multiple patterns
 --allow-urls "https://github.com/org1/*,https://api.github.com/repos/*"

--- a/docs-site/src/content/docs/reference/security-architecture.md
+++ b/docs-site/src/content/docs/reference/security-architecture.md
@@ -212,7 +212,7 @@ Only enable SSL Bump when you specifically need URL path filtering. For most use
 ### SSL Bump Threat Considerations
 
 **What SSL Bump enables:**
-- Fine-grained access control (e.g., allow only `/githubnext/*` paths)
+- Fine-grained access control (e.g., allow only `/myorg/*` paths)
 - Better audit logging with full URLs
 - Detection of path-based exfiltration attempts
 

--- a/docs-site/src/content/docs/reference/ssl-bump.md
+++ b/docs-site/src/content/docs/reference/ssl-bump.md
@@ -20,7 +20,7 @@ SSL Bump enables deep inspection of HTTPS traffic, allowing URL path filtering i
 
 ## Overview
 
-By default, awf filters HTTPS traffic based on domain names using SNI (Server Name Indication). You can allow `github.com`, but cannot restrict access to specific paths like `https://github.com/githubnext/*`.
+By default, awf filters HTTPS traffic based on domain names using SNI (Server Name Indication). You can allow `github.com`, but cannot restrict access to specific paths like `https://github.com/myorg/*`.
 
 With SSL Bump enabled, the firewall generates a per-session CA certificate and intercepts HTTPS connections, enabling:
 
@@ -39,8 +39,8 @@ SSL Bump intercepts and decrypts HTTPS traffic. The proxy can see full request U
 sudo awf \
   --allow-domains github.com \
   --ssl-bump \
-  --allow-urls "https://github.com/githubnext/*,https://api.github.com/repos/*" \
-  -- curl https://github.com/githubnext/some-repo
+  --allow-urls "https://github.com/myorg/*,https://api.github.com/repos/*" \
+  -- curl https://github.com/myorg/some-repo
 ```
 
 ## CLI Flags
@@ -77,13 +77,13 @@ Comma-separated list of allowed URL patterns for HTTPS traffic.
 
 ```bash
 # Allow specific repository paths
---allow-urls "https://github.com/githubnext/*"
+--allow-urls "https://github.com/myorg/*"
 
 # Allow API endpoints
 --allow-urls "https://api.github.com/repos/*,https://api.github.com/users/*"
 
 # Combine with domain allowlist
---allow-domains github.com --ssl-bump --allow-urls "https://github.com/githubnext/*"
+--allow-domains github.com --ssl-bump --allow-urls "https://github.com/myorg/*"
 ```
 
 ## How It Works
@@ -103,7 +103,7 @@ Squid sees only the domain from the TLS ClientHello SNI extension. The URL path 
 Agent → CONNECT github.com:443 → Squid intercepts TLS
       → Squid presents session CA certificate
       → Agent trusts session CA (injected into trust store)
-      → Full HTTPS request visible: GET /githubnext/repo
+      → Full HTTPS request visible: GET /myorg/repo
       → Squid checks URL pattern ACL → Pass/Block
 ```
 
@@ -189,11 +189,11 @@ To prevent security bypasses, URL patterns (`--allow-urls`) are validated:
 sudo awf \
   --allow-domains github.com \
   --ssl-bump \
-  --allow-urls "https://github.com/githubnext/*,https://github.com/github/*" \
-  -- copilot --prompt "Clone the githubnext/copilot-workspace repo"
+  --allow-urls "https://github.com/myorg/*,https://github.com/github/*" \
+  -- copilot --prompt "Clone the myorg/copilot-workspace repo"
 ```
 
-Allows access to `githubnext` and `github` organizations while blocking other repositories.
+Allows access to `myorg` and `github` organizations while blocking other repositories.
 
 ### API Endpoint Restrictions
 
@@ -201,7 +201,7 @@ Allows access to `githubnext` and `github` organizations while blocking other re
 sudo awf \
   --allow-domains api.github.com \
   --ssl-bump \
-  --allow-urls "https://api.github.com/repos/githubnext/*,https://api.github.com/users/*" \
+  --allow-urls "https://api.github.com/repos/myorg/*,https://api.github.com/users/*" \
   -- curl https://api.github.com/repos/github/gh-aw-firewall
 ```
 
@@ -261,8 +261,8 @@ sudo awf --log-level debug --ssl-bump --allow-urls "..." -- your-command
 sudo cat /tmp/squid-logs-*/access.log | grep your-domain
 
 # Ensure patterns include scheme (https://)
-# ✗ Wrong: github.com/githubnext/*
-# ✓ Correct: https://github.com/githubnext/*
+# ✗ Wrong: github.com/myorg/*
+# ✓ Correct: https://github.com/myorg/*
 ```
 
 ## Known Limitations

--- a/docs/ssl-bump.md
+++ b/docs/ssl-bump.md
@@ -13,7 +13,7 @@ SSL Bump enables deep inspection of HTTPS traffic, allowing URL path filtering i
 
 ## Overview
 
-By default, awf filters HTTPS traffic based on domain names using SNI (Server Name Indication). This means you can allow or block `github.com`, but you cannot restrict access to specific paths like `https://github.com/githubnext/*`.
+By default, awf filters HTTPS traffic based on domain names using SNI (Server Name Indication). This means you can allow or block `github.com`, but you cannot restrict access to specific paths like `https://github.com/myorg/*`.
 
 With SSL Bump enabled (`--ssl-bump`), the firewall generates a per-session CA certificate and intercepts HTTPS connections. This allows:
 
@@ -28,8 +28,8 @@ With SSL Bump enabled (`--ssl-bump`), the firewall generates a per-session CA ce
 sudo awf \
   --allow-domains github.com \
   --ssl-bump \
-  --allow-urls "https://github.com/githubnext/*,https://api.github.com/repos/*" \
-  -- curl https://github.com/githubnext/some-repo
+  --allow-urls "https://github.com/myorg/*,https://api.github.com/repos/*" \
+  -- curl https://github.com/myorg/some-repo
 ```
 
 ## CLI Flags
@@ -61,13 +61,13 @@ Comma-separated list of allowed URL patterns for HTTPS traffic. Requires `--ssl-
 **Examples:**
 ```bash
 # Allow specific repository paths
---allow-urls "https://github.com/githubnext/*"
+--allow-urls "https://github.com/myorg/*"
 
 # Allow API endpoints
 --allow-urls "https://api.github.com/repos/*,https://api.github.com/users/*"
 
 # Combine with domain allowlist
---allow-domains github.com --ssl-bump --allow-urls "https://github.com/githubnext/*"
+--allow-domains github.com --ssl-bump --allow-urls "https://github.com/myorg/*"
 ```
 
 ## How It Works
@@ -87,7 +87,7 @@ Squid sees only the domain from the TLS ClientHello SNI extension. The URL path 
 Agent → CONNECT github.com:443 → Squid intercepts TLS
       → Squid presents session CA certificate
       → Agent trusts session CA (injected into trust store)
-      → Full HTTPS request visible: GET /githubnext/repo
+      → Full HTTPS request visible: GET /myorg/repo
       → Squid checks URL pattern ACL → Pass/Block
 ```
 
@@ -109,11 +109,11 @@ Squid terminates the TLS connection and establishes a new encrypted connection t
 sudo awf \
   --allow-domains github.com \
   --ssl-bump \
-  --allow-urls "https://github.com/githubnext/*,https://github.com/github/*" \
-  -- copilot --prompt "Clone the githubnext/copilot-workspace repo"
+  --allow-urls "https://github.com/myorg/*,https://github.com/github/*" \
+  -- copilot --prompt "Clone the myorg/copilot-workspace repo"
 ```
 
-This allows access to repositories under `githubnext` and `github` organizations, but blocks access to other GitHub repositories.
+This allows access to repositories under `myorg` and `github` organizations, but blocks access to other GitHub repositories.
 
 ### API Endpoint Restrictions
 
@@ -121,7 +121,7 @@ This allows access to repositories under `githubnext` and `github` organizations
 sudo awf \
   --allow-domains api.github.com \
   --ssl-bump \
-  --allow-urls "https://api.github.com/repos/githubnext/*,https://api.github.com/users/*" \
+  --allow-urls "https://api.github.com/repos/myorg/*,https://api.github.com/users/*" \
   -- curl https://api.github.com/repos/github/gh-aw-firewall
 ```
 
@@ -261,8 +261,8 @@ sudo awf --log-level debug --ssl-bump --allow-urls "..." -- your-command
 sudo cat /tmp/squid-logs-*/access.log | grep your-domain
 
 # Ensure patterns include scheme (https://)
-# ✗ Wrong: github.com/githubnext/*
-# ✓ Correct: https://github.com/githubnext/*
+# ✗ Wrong: github.com/myorg/*
+# ✓ Correct: https://github.com/myorg/*
 ```
 
 ### Performance Impact

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -342,8 +342,8 @@ docker exec awf-agent dmesg | grep FW_BLOCKED
    ```
 3. Ensure patterns include the scheme:
    ```bash
-   # ✗ Wrong: github.com/githubnext/*
-   # ✓ Correct: https://github.com/githubnext/*
+   # ✗ Wrong: github.com/myorg/*
+   # ✓ Correct: https://github.com/myorg/*
    ```
 
 ### Application Fails with Certificate Pinning

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ Options:
                              (see "Host Access" section for security implications)
   --ssl-bump                 Enable SSL Bump for HTTPS content inspection
   --allow-urls <urls>        Comma-separated list of allowed URL patterns (requires --ssl-bump)
-                             Example: https://github.com/githubnext/*,https://api.github.com/repos/*
+                             Example: https://github.com/myorg/*,https://api.github.com/repos/*
   --log-level <level>        Log level: debug, info, warn, error (default: info)
   --keep-containers          Keep containers running after command exits
   --work-dir <dir>           Working directory for temporary files
@@ -306,8 +306,8 @@ By default, awf filters HTTPS traffic based on domain names only (using SNI). En
 sudo awf \
   --allow-domains github.com \
   --ssl-bump \
-  --allow-urls "https://github.com/githubnext/*" \
-  'curl https://github.com/githubnext/some-repo'
+  --allow-urls "https://github.com/myorg/*" \
+  'curl https://github.com/myorg/some-repo'
 ```
 
 ### URL Pattern Syntax
@@ -316,7 +316,7 @@ URL patterns support wildcards:
 
 ```bash
 # Match any path under an organization
---allow-urls "https://github.com/githubnext/*"
+--allow-urls "https://github.com/myorg/*"
 
 # Match specific API endpoints
 --allow-urls "https://api.github.com/repos/*,https://api.github.com/users/*"

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -6,7 +6,7 @@
  * Usage: node scripts/generate-release-notes.js <changelog_file> <cli_help_file> <output_file>
  *
  * Environment variables:
- *   REPOSITORY - GitHub repository (e.g., githubnext/gh-aw-firewall)
+ *   REPOSITORY - GitHub repository (e.g., github/gh-aw-firewall)
  *   VERSION - Version tag (e.g., v0.3.0)
  *   VERSION_NUMBER - Version number without v prefix (e.g., 0.3.0)
  */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -558,7 +558,7 @@ program
   .option(
     '--allow-urls <urls>',
     'Comma-separated list of allowed URL patterns for HTTPS (requires --ssl-bump).\n' +
-    '                                   Supports wildcards: https://github.com/githubnext/*'
+    '                                   Supports wildcards: https://github.com/myorg/*'
   )
   .option(
     '--enable-chroot',
@@ -756,7 +756,7 @@ program
         if (!urlWithoutScheme.includes('/')) {
           logger.error(`URL pattern "${url}" must include a path component`);
           logger.error('For domain-only filtering, use --allow-domains instead');
-          logger.error('Example: https://github.com/githubnext/* (includes path)');
+          logger.error('Example: https://github.com/myorg/* (includes path)');
           process.exit(1);
         }
       }

--- a/src/squid-config.test.ts
+++ b/src/squid-config.test.ts
@@ -1065,11 +1065,11 @@ describe('generateSquidConfig', () => {
           keyPath: '/tmp/test/ssl/ca-key.pem',
         },
         sslDbPath: '/tmp/test/ssl_db',
-        urlPatterns: ['^https://github\\.com/githubnext/[^\\s]*'],
+        urlPatterns: ['^https://github\\.com/myorg/[^\\s]*'],
       };
       const result = generateSquidConfig(config);
       expect(result).toContain('acl allowed_url_0 url_regex');
-      expect(result).toContain('^https://github\\.com/githubnext/[^\\s]*');
+      expect(result).toContain('^https://github\\.com/myorg/[^\\s]*');
     });
 
     it('should not include SSL Bump section when disabled', () => {

--- a/src/ssl-bump.test.ts
+++ b/src/ssl-bump.test.ts
@@ -11,8 +11,8 @@ describe('SSL Bump', () => {
     });
 
     it('should convert * wildcard to safe regex pattern', () => {
-      const patterns = parseUrlPatterns(['https://github.com/githubnext/*']);
-      expect(patterns).toEqual([`^https://github\\.com/githubnext/${URL_CHAR_PATTERN}`]);
+      const patterns = parseUrlPatterns(['https://github.com/myorg/*']);
+      expect(patterns).toEqual([`^https://github\\.com/myorg/${URL_CHAR_PATTERN}`]);
     });
 
     it('should handle multiple wildcards', () => {
@@ -42,11 +42,11 @@ describe('SSL Bump', () => {
 
     it('should handle multiple patterns', () => {
       const patterns = parseUrlPatterns([
-        'https://github.com/githubnext/*',
+        'https://github.com/myorg/*',
         'https://api.example.com/v1/*',
       ]);
       expect(patterns).toHaveLength(2);
-      expect(patterns[0]).toBe(`^https://github\\.com/githubnext/${URL_CHAR_PATTERN}`);
+      expect(patterns[0]).toBe(`^https://github\\.com/myorg/${URL_CHAR_PATTERN}`);
       expect(patterns[1]).toBe(`^https://api\\.example\\.com/v1/${URL_CHAR_PATTERN}`);
     });
 

--- a/src/ssl-bump.ts
+++ b/src/ssl-bump.ts
@@ -184,7 +184,7 @@ const URL_CHAR_PATTERN = '[^\\s]*';
  * Converts user-friendly URL patterns into Squid url_regex ACL patterns.
  *
  * Examples:
- * - `https://github.com/githubnext/*` → `^https://github\.com/githubnext/[^\s]*`
+ * - `https://github.com/myorg/*` → `^https://github\.com/myorg/[^\s]*`
  * - `https://api.example.com/v1/users` → `^https://api\.example\.com/v1/users$`
  *
  * @param patterns - Array of URL patterns (can include wildcards)

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,7 +323,7 @@ export interface WrapperConfig {
    *
    * If not specified, falls back to domain-only filtering.
    *
-   * @example ['https://github.com/githubnext/*', 'https://api.example.com/v1/*']
+   * @example ['https://github.com/myorg/*', 'https://api.example.com/v1/*']
    */
   allowedUrls?: string[];
 


### PR DESCRIPTION
## Summary

- Update docs-site config to use `github.github.io`
- Update references to `github/agentics` repository
- Update example URL patterns from `githubnext` to `myorg` (generic examples)
- Update project links to `github.github.io/gh-aw/`

This PR completes the migration from `githubnext` org to `github` org that was started in #474.

## Test plan

- [x] Build passes
- [x] All 661 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)