### PR TITLE
fix: replace deprecated log_access directive with Squid 5+ syntax

### DIFF
--- a/src/squid-config.ts
+++ b/src/squid-config.ts
@@ -511,12 +511,10 @@ pinger_enable off
 # Note: For CONNECT requests (HTTPS), the domain is in the URL field
 logformat firewall_detailed %ts.%03tu %>a:%>p %{Host}>h %<a:%<p %rv %rm %>Hs %Ss:%Sh %ru "%{User-Agent}>h"
 
-# Don't log healthcheck probes from localhost
-acl healthcheck_localhost src 127.0.0.1 ::1
-log_access deny healthcheck_localhost
-
 # Access log and cache configuration
-access_log /var/log/squid/access.log firewall_detailed
+# Don't log healthcheck probes from localhost (using ACL filter on access_log)
+acl healthcheck_localhost src 127.0.0.1 ::1
+access_log /var/log/squid/access.log firewall_detailed !healthcheck_localhost
 cache_log /var/log/squid/cache.log
 cache deny all
 


### PR DESCRIPTION
## Summary

- Fixes CI breakage caused by deprecated `log_access` directive in Squid 5+
- Replaces with modern ACL filter syntax on `access_log` directive
- Updates tests to verify new syntax

## Problem

After merging PR #432, CI started failing because the Squid container was crashing immediately on startup with exit code 1. The root cause is that the `log_access` directive was removed from Squid starting with version 5.0, and the `ubuntu/squid:latest` Docker image uses Squid 5+.

## Solution

Replace the deprecated syntax:
```squid
acl healthcheck_localhost src 127.0.0.1 ::1
log_access deny healthcheck_localhost
access_log /var/log/squid/access.log firewall_detailed
```

With the modern Squid 5+ syntax:
```squid
acl healthcheck_localhost src 127.0.0.1 ::1
access_log /var/log/squid/access.log firewall_detailed !healthcheck_localhost
```

The `!` negates the ACL, meaning "log everything EXCEPT healthcheck_localhost".

## Test plan

- [x] Unit tests pass (`npm test -- squid-config.test.ts` - 119 tests pass)
- [x] Manual integration test: `sudo awf --allow-domains github.com -- curl -s https://api.github.com/zen` completes successfully
- [ ] CI integration tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)