### PR TITLE
fix: add auth and error handling to build-test workflows

### DIFF
--- a/.github/workflows/build-test-bun.lock.yml
+++ b/.github/workflows/build-test-bun.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Bun
 #
-# frontmatter-hash: 906745d65c7563d374e0e90a495fdb64eac39fd1bc615b4ba12a4f6f6fb0191b
+# frontmatter-hash: 2f4301a31bfbc25351b8a0af6b02d4f08de0bc7cfdcbc7a480d4344047bfe341
 
 name: "Build Test Bun"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Bun"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-bun.md
+++ b/.github/workflows/build-test-bun.md
@@ -33,6 +33,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 15
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Bun
@@ -48,7 +50,8 @@ strict: true
    export PATH="$BUN_INSTALL/bin:$PATH"
    ```
 
-2. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-bun.git /tmp/test-bun`
+2. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-bun /tmp/test-bun`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 3. **Test Projects**:
    - `elysia`: `cd /tmp/test-bun/elysia && bun install && bun test`
@@ -72,3 +75,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-bun` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Bun install failure**: Call `safeoutputs-missing_tool` with "BUN_INSTALL_FAILED: [error message]"
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-cpp.lock.yml
+++ b/.github/workflows/build-test-cpp.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test C++
 #
-# frontmatter-hash: c6f87d57c374db40b39cdd0ba9674369010e59e614cb07fdeacac77e173b4746
+# frontmatter-hash: 6d6d9e3536984f9e2b74117ee6ca684a631c272a27bfc4f5dec690379c8bdd61
 
 name: "Build Test C++"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test C++"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-cpp.md
+++ b/.github/workflows/build-test-cpp.md
@@ -31,6 +31,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 30
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: C++
@@ -41,7 +43,8 @@ strict: true
 
 Clone and test the following projects from the test repository:
 
-1. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-cpp.git /tmp/test-cpp`
+1. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-cpp /tmp/test-cpp`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 2. **Test Projects**:
    - `fmt`:
@@ -77,3 +80,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL builds pass, add the label `build-test-cpp` to the pull request.
 If ANY build fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **CMake failure**: Report in comment table with ❌ and include error output
+3. **Build failure**: Report in comment table with ❌ and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-deno.lock.yml
+++ b/.github/workflows/build-test-deno.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Deno
 #
-# frontmatter-hash: f31e23cf2341592bc3b077bdf6e86b8b16bc45c95e42f61819bdbece33a8a84d
+# frontmatter-hash: bfb4bcac6539c4dbbab1691bb87bd0b77e8872cd1568fd8ab757bb449e70a304
 
 name: "Build Test Deno"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Deno"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-deno.md
+++ b/.github/workflows/build-test-deno.md
@@ -35,6 +35,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 15
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Deno
@@ -50,7 +52,8 @@ strict: true
    export PATH="$DENO_INSTALL/bin:$PATH"
    ```
 
-2. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-deno.git /tmp/test-deno`
+2. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-deno /tmp/test-deno`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 3. **Test Projects**:
    - `oak`: `cd /tmp/test-deno/oak && deno test`
@@ -73,3 +76,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-deno` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Deno install failure**: Call `safeoutputs-missing_tool` with "DENO_INSTALL_FAILED: [error message]"
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-go.lock.yml
+++ b/.github/workflows/build-test-go.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Go
 #
-# frontmatter-hash: cd7b885a38fc778df945edc6e901348ddb23b8362dc53bcc98bc880e92db25ee
+# frontmatter-hash: 2f8058dacf12d3b862058a1d7158d702c4b00860ad222565fcb3be9f4adf99c6
 
 name: "Build Test Go"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Go"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-go.md
+++ b/.github/workflows/build-test-go.md
@@ -35,6 +35,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 15
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Go
@@ -45,7 +47,8 @@ strict: true
 
 Clone and test the following projects from the test repository:
 
-1. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-go.git /tmp/test-go`
+1. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-go /tmp/test-go`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 2. **Test Projects**:
    - `color`: `cd /tmp/test-go/color && go mod download && go test ./...`
@@ -71,3 +74,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-go` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Download failure**: Report in comment table with ❌ and include error output
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-java.lock.yml
+++ b/.github/workflows/build-test-java.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Java
 #
-# frontmatter-hash: c3f5c8718c0982d8651752b28a8d7cfe2fdb62769550c0a593b9e21522aca60d
+# frontmatter-hash: 03a5b8a44629dd2513cc7dda38dfe03f696afb41f1bcafa03fc7dd9f4debf18c
 
 name: "Build Test Java"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Java"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-java.md
+++ b/.github/workflows/build-test-java.md
@@ -35,6 +35,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 15
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Java
@@ -45,7 +47,8 @@ strict: true
 
 Clone and test the following projects from the test repository:
 
-1. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-java.git /tmp/test-java`
+1. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-java /tmp/test-java`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 2. **Test Projects**:
    - `gson`: `cd /tmp/test-java/gson && mvn compile && mvn test`
@@ -69,3 +72,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-java` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Build failure**: Report in comment table with ❌ and include error output
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-node.lock.yml
+++ b/.github/workflows/build-test-node.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Node.js
 #
-# frontmatter-hash: aacf85c55bc6eb73b3135685939f76197e7523392193ff2b910f1c300a0fc6c0
+# frontmatter-hash: 99bef0aa4f8ef6862f12518c00795d4d8b6af6296286d68059476b89f380961b
 
 name: "Build Test Node.js"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Node.js"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-node.md
+++ b/.github/workflows/build-test-node.md
@@ -35,6 +35,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 15
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Node.js
@@ -45,7 +47,8 @@ strict: true
 
 Clone and test the following projects from the test repository:
 
-1. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-node.git /tmp/test-node`
+1. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-node /tmp/test-node`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 2. **Test Projects**:
    - `clsx`: `cd /tmp/test-node/clsx && npm install && npm test`
@@ -71,3 +74,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-node` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Install failure**: Report in comment table with ❌ and include error output
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.

--- a/.github/workflows/build-test-rust.lock.yml
+++ b/.github/workflows/build-test-rust.lock.yml
@@ -21,7 +21,7 @@
 #
 # Build Test Rust
 #
-# frontmatter-hash: f6fe06ba8d893bda313c684d5ca5da3830fe44ece492c338567b78b901d91820
+# frontmatter-hash: ce653278c404e9224b068baacf3bdd06b6735c2759288f0faf0121c7381f3b53
 
 name: "Build Test Rust"
 "on":
@@ -39,6 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 run-name: "Build Test Rust"
+
+env:
+  GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 
 jobs:
   activation:

--- a/.github/workflows/build-test-rust.md
+++ b/.github/workflows/build-test-rust.md
@@ -35,6 +35,8 @@ safe-outputs:
     run-failure: "**Build Test Failed** [{workflow_name}]({run_url}) - See logs for details"
 timeout-minutes: 30
 strict: true
+env:
+  GH_TOKEN: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}"
 ---
 
 # Build Test: Rust
@@ -45,7 +47,8 @@ strict: true
 
 Clone and test the following projects from the test repository:
 
-1. **Clone Repository**: `git clone https://github.com/Mossaka/gh-aw-firewall-test-rust.git /tmp/test-rust`
+1. **Clone Repository**: `gh repo clone Mossaka/gh-aw-firewall-test-rust /tmp/test-rust`
+   - **CRITICAL**: If clone fails, immediately call `safeoutputs-missing_tool` with message "CLONE_FAILED: Unable to clone test repository" and stop execution
 
 2. **Test Projects**:
    - `fd`: `cd /tmp/test-rust/fd && cargo build && cargo test`
@@ -69,3 +72,13 @@ Add a comment to the current pull request with a summary table:
 
 If ALL tests pass, add the label `build-test-rust` to the pull request.
 If ANY test fails, report the failure with error details.
+
+## Error Handling
+
+**CRITICAL**: This workflow MUST fail visibly when errors occur:
+
+1. **Clone failure**: If repository clone fails, call `safeoutputs-missing_tool` with "CLONE_FAILED: [error message]"
+2. **Build failure**: Report in comment table with ❌ and include error output
+3. **Test failure**: Report in comment table with FAIL status and include failure details
+
+DO NOT report success if any step fails. The workflow should produce a clear, actionable error message.


### PR DESCRIPTION
## Summary

- Add `env.GH_TOKEN` using `GH_AW_GITHUB_MCP_SERVER_TOKEN` secret for repository cloning
- Change `git clone` to `gh repo clone` (uses GH_TOKEN automatically)
- Add explicit failure handling instructions in prompts
- Workflows now fail visibly when clone/build/test fails instead of silently succeeding

## Problem

The build-test workflows were showing as "success" even when they couldn't clone the test repositories due to authentication issues. The workflows use `git clone` directly which doesn't have access to GitHub credentials.

## Solution

1. **Add GH_TOKEN environment variable**: Each workflow now passes `GH_AW_GITHUB_MCP_SERVER_TOKEN` as `GH_TOKEN` to the agent container
2. **Use gh repo clone**: Changed from `git clone https://...` to `gh repo clone owner/repo` which automatically uses the `GH_TOKEN` environment variable
3. **Explicit error handling**: Added instructions in each workflow prompt to call `safeoutputs-missing_tool` with clear error messages when clone fails

## Affected Workflows

- build-test-java
- build-test-rust
- build-test-node
- build-test-go
- build-test-cpp
- build-test-deno
- build-test-bun

## Test Plan

- [ ] Trigger each build-test workflow
- [ ] Verify workflows can now clone the test repositories
- [ ] Verify workflows fail with clear error messages if authentication or clone fails

🤖 Generated with [Claude Code](https://claude.ai/claude-code)