### PR TITLE
fix: remove HTTP_PROXY/HTTPS_PROXY env vars from agent container

### DIFF
--- a/containers/agent/entrypoint.sh
+++ b/containers/agent/entrypoint.sh
@@ -115,9 +115,13 @@ fi
 /usr/local/bin/setup-iptables.sh
 
 # Print proxy environment
-echo "[entrypoint] Proxy configuration:"
-echo "[entrypoint]   HTTP_PROXY=$HTTP_PROXY"
-echo "[entrypoint]   HTTPS_PROXY=$HTTPS_PROXY"
+echo "[entrypoint] Proxy configuration: intercept mode (iptables DNAT 80/443 -> squid:${SQUID_INTERCEPT_PORT})"
+if [ -n "$HTTP_PROXY" ]; then
+  echo "[entrypoint]   HTTP_PROXY=$HTTP_PROXY (user-provided)"
+fi
+if [ -n "$HTTPS_PROXY" ]; then
+  echo "[entrypoint]   HTTPS_PROXY=$HTTPS_PROXY (user-provided)"
+fi
 
 # Print network information
 echo "[entrypoint] Network information:"

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -319,14 +319,16 @@ export function generateDockerCompose(
     'SUDO_USER',      // Sudo metadata
     'SUDO_UID',       // Sudo metadata
     'SUDO_GID',       // Sudo metadata
+    'HTTP_PROXY',     // Intercept mode handles routing; explicit proxy is unreachable
+    'HTTPS_PROXY',    // Intercept mode handles routing; explicit proxy is unreachable
+    'http_proxy',     // Lowercase variant
+    'https_proxy',    // Lowercase variant
   ]);
 
   // Start with required/overridden environment variables
   // For chroot mode, use the real user's home (not /root when running with sudo)
   const homeDir = config.enableChroot ? getRealUserHome() : (process.env.HOME || '/root');
   const environment: Record<string, string> = {
-    HTTP_PROXY: `http://${networkConfig.squidIp}:${SQUID_PORT}`,
-    HTTPS_PROXY: `http://${networkConfig.squidIp}:${SQUID_PORT}`,
     SQUID_PROXY_HOST: 'squid-proxy',
     SQUID_PROXY_PORT: SQUID_PORT.toString(),
     SQUID_INTERCEPT_PORT: SQUID_INTERCEPT_PORT.toString(),


### PR DESCRIPTION
## Summary

- Remove `HTTP_PROXY`/`HTTPS_PROXY` env vars from the agent container environment — intercept mode (iptables DNAT 80/443 → squid:3129) handles all routing transparently
- Add proxy vars (upper and lowercase) to `EXCLUDED_ENV_VARS` to prevent host proxy settings leaking via `--env-all`
- Update `entrypoint.sh` logging to reflect intercept mode instead of unconditionally printing empty proxy vars

## Problem

Codex (Rust/reqwest) honors the `HTTP_PROXY` env var and attempts to connect to squid on port 3128. In intercept mode, port 3128 is not reachable from the agent container (only port 3129 via iptables DNAT), causing "Connection refused" errors. Copilot and Claude work fine because they don't use `HTTP_PROXY` the same way.

## What does NOT change

- Squid still listens on port 3128 (healthcheck uses it)
- `SQUID_PROXY_HOST`, `SQUID_PROXY_PORT`, `SQUID_INTERCEPT_PORT` env vars remain (used by `setup-iptables.sh`)
- Docker Compose port mapping for 3128/3129 remains
- `--env` override path still works for explicit proxy if needed

## Test plan

- [x] Unit tests pass (731 tests, all passing)
- [x] Build succeeds
- [x] Lint passes (0 errors)
- [ ] Codex smoke test to verify fix

Fixes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)