### PR TITLE
fix: bypass Squid intercept for host.docker.internal traffic

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -1053,6 +1053,29 @@ describe('docker-manager', () => {
         expect(agent.extra_hosts).toBeUndefined();
         expect(squid.extra_hosts).toBeUndefined();
       });
+
+      it('should set AWF_ENABLE_HOST_ACCESS env var when enableHostAccess is true', () => {
+        const config = { ...mockConfig, enableHostAccess: true };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env.AWF_ENABLE_HOST_ACCESS).toBe('1');
+      });
+
+      it('should NOT set AWF_ENABLE_HOST_ACCESS env var when enableHostAccess is false', () => {
+        const config = { ...mockConfig, enableHostAccess: false };
+        const result = generateDockerCompose(config, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env.AWF_ENABLE_HOST_ACCESS).toBeUndefined();
+      });
+
+      it('should NOT set AWF_ENABLE_HOST_ACCESS env var when enableHostAccess is undefined', () => {
+        const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env.AWF_ENABLE_HOST_ACCESS).toBeUndefined();
+      });
     });
 
     describe('allowHostPorts option', () => {

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -566,6 +566,7 @@ export function generateDockerCompose(
   // Enable host.docker.internal for agent when --enable-host-access is set
   if (config.enableHostAccess) {
     agentService.extra_hosts = ['host.docker.internal:host-gateway'];
+    environment.AWF_ENABLE_HOST_ACCESS = '1';
   }
 
   // Use GHCR image or build locally


### PR DESCRIPTION
## Summary

- When `--enable-host-access` is used, MCP gateway HTTP traffic to `host.docker.internal` gets DNAT'd to Squid's intercept port via iptables, where `ORIGINAL_DST` lookup fails (different network namespace), causing Squid crashes under heavy MCP load (~13,000 requests)
- Adds iptables RETURN rule for the host gateway IP when `AWF_ENABLE_HOST_ACCESS` env var is set, so traffic to `host.docker.internal` bypasses Squid entirely
- Passes `AWF_ENABLE_HOST_ACCESS=1` from `docker-manager.ts` to the agent container when `enableHostAccess` is true

## Changes

1. **`containers/agent/setup-iptables.sh`**: After the Squid proxy bypass rule, resolves `host.docker.internal` and adds `iptables -t nat RETURN` + `iptables OUTPUT ACCEPT` rules for that IP
2. **`src/docker-manager.ts`**: Sets `AWF_ENABLE_HOST_ACCESS=1` env var in the agent container when `config.enableHostAccess` is true
3. **`src/docker-manager.test.ts`**: 3 new tests verifying the env var is set/unset correctly

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 736 tests pass (including 3 new)
- [ ] CI: build, lint, unit tests
- [ ] CI: integration/smoke tests (validates host access + MCP gateway under load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)