### PR TITLE
fix: mount /etc/hosts in chroot mode for localhost resolution

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -557,6 +557,7 @@ describe('docker-manager', () => {
       expect(volumes).toContain('/etc/ca-certificates:/host/etc/ca-certificates:ro');
       expect(volumes).toContain('/etc/alternatives:/host/etc/alternatives:ro');
       expect(volumes).toContain('/etc/ld.so.cache:/host/etc/ld.so.cache:ro');
+      expect(volumes).toContain('/etc/hosts:/host/etc/hosts:ro');
 
       // Should still include essential mounts
       expect(volumes).toContain('/tmp:/tmp:rw');

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -469,6 +469,7 @@ export function generateDockerCompose(
       '/etc/passwd:/host/etc/passwd:ro',                   // User database (needed for getent/user lookup)
       '/etc/group:/host/etc/group:ro',                     // Group database (needed for getent/group lookup)
       '/etc/nsswitch.conf:/host/etc/nsswitch.conf:ro',     // Name service switch config
+      '/etc/hosts:/host/etc/hosts:ro',                     // Host name resolution (localhost, etc.)
     );
 
     // SECURITY: Hide Docker socket to prevent firewall bypass via 'docker run'


### PR DESCRIPTION
## Summary

- In chroot mode with selective `/etc` mounts, `/etc/hosts` was not mounted, causing tools like JSDOM/Vitest to fail with `getaddrinfo EAI_AGAIN localhost`
- Add a read-only bind mount of `/etc/hosts` into the chroot (`/etc/hosts:/host/etc/hosts:ro`)
- Since `/host` is the real host root filesystem, a read-only bind mount is the safest approach — no mutation, no cleanup needed

## Test plan

- [x] `npm run build` compiles
- [x] `npm test` — 728 unit tests pass (including new assertion)
- [x] `npm run lint` — no errors
- [ ] Verify `getent hosts localhost` resolves inside chroot

🤖 Generated with [Claude Code](https://claude.com/claude-code)