### PR TITLE
fix: pass BUN_INSTALL to chroot to prevent Bun core dump

### DIFF
--- a/containers/agent/entrypoint.sh
+++ b/containers/agent/entrypoint.sh
@@ -239,6 +239,13 @@ AWFEOF
       echo "export PATH=\"${AWF_GOROOT}/bin:\$PATH\"" >> "/host${SCRIPT_FILE}"
       echo "export GOROOT=\"${AWF_GOROOT}\"" >> "/host${SCRIPT_FILE}"
     fi
+    # Add BUN_INSTALL/bin to PATH if provided (for Bun on GitHub Actions)
+    # Bun must be pre-installed on the host because it crashes inside chroot (restricted /proc)
+    if [ -n "${AWF_BUN_INSTALL}" ]; then
+      echo "[entrypoint] Adding BUN_INSTALL/bin to PATH: ${AWF_BUN_INSTALL}/bin"
+      echo "export PATH=\"${AWF_BUN_INSTALL}/bin:\$PATH\"" >> "/host${SCRIPT_FILE}"
+      echo "export BUN_INSTALL=\"${AWF_BUN_INSTALL}\"" >> "/host${SCRIPT_FILE}"
+    fi
   else
     echo "[entrypoint] Constructing default PATH for chroot"
     cat > "/host${SCRIPT_FILE}" << 'AWFEOF'

--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -623,14 +623,16 @@ describe('docker-manager', () => {
       expect(environment.AWF_CHROOT_ENABLED).toBe('true');
     });
 
-    it('should pass GOROOT, CARGO_HOME, JAVA_HOME to container when enableChroot is true and env vars are set', () => {
+    it('should pass GOROOT, CARGO_HOME, JAVA_HOME, BUN_INSTALL to container when enableChroot is true and env vars are set', () => {
       const originalGoroot = process.env.GOROOT;
       const originalCargoHome = process.env.CARGO_HOME;
       const originalJavaHome = process.env.JAVA_HOME;
+      const originalBunInstall = process.env.BUN_INSTALL;
 
       process.env.GOROOT = '/usr/local/go';
       process.env.CARGO_HOME = '/home/user/.cargo';
       process.env.JAVA_HOME = '/usr/lib/jvm/java-17';
+      process.env.BUN_INSTALL = '/home/user/.bun';
 
       try {
         const configWithChroot = {
@@ -644,6 +646,7 @@ describe('docker-manager', () => {
         expect(environment.AWF_GOROOT).toBe('/usr/local/go');
         expect(environment.AWF_CARGO_HOME).toBe('/home/user/.cargo');
         expect(environment.AWF_JAVA_HOME).toBe('/usr/lib/jvm/java-17');
+        expect(environment.AWF_BUN_INSTALL).toBe('/home/user/.bun');
       } finally {
         // Restore original values
         if (originalGoroot !== undefined) {
@@ -660,6 +663,32 @@ describe('docker-manager', () => {
           process.env.JAVA_HOME = originalJavaHome;
         } else {
           delete process.env.JAVA_HOME;
+        }
+        if (originalBunInstall !== undefined) {
+          process.env.BUN_INSTALL = originalBunInstall;
+        } else {
+          delete process.env.BUN_INSTALL;
+        }
+      }
+    });
+
+    it('should NOT set AWF_BUN_INSTALL when BUN_INSTALL is not in environment', () => {
+      const originalBunInstall = process.env.BUN_INSTALL;
+      delete process.env.BUN_INSTALL;
+
+      try {
+        const configWithChroot = {
+          ...mockConfig,
+          enableChroot: true
+        };
+        const result = generateDockerCompose(configWithChroot, mockNetworkConfig);
+        const agent = result.services.agent;
+        const environment = agent.environment as Record<string, string>;
+
+        expect(environment.AWF_BUN_INSTALL).toBeUndefined();
+      } finally {
+        if (originalBunInstall !== undefined) {
+          process.env.BUN_INSTALL = originalBunInstall;
         }
       }
     });

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -353,6 +353,12 @@ export function generateDockerCompose(
     if (process.env.JAVA_HOME) {
       environment.AWF_JAVA_HOME = process.env.JAVA_HOME;
     }
+    // Bun: Pass BUN_INSTALL so entrypoint can add $BUN_INSTALL/bin to PATH
+    // Bun crashes with core dump when installed inside chroot (restricted /proc access),
+    // so it must be pre-installed on the host via setup-bun action
+    if (process.env.BUN_INSTALL) {
+      environment.AWF_BUN_INSTALL = process.env.BUN_INSTALL;
+    }
   }
 
   // If --env-all is specified, pass through all host environment variables (except excluded ones)


### PR DESCRIPTION
## Summary

- Bun crashes with a core dump when installed inside the chroot because `/proc` access is restricted to `/proc/self` only
- Pass `BUN_INSTALL` from the host environment as `AWF_BUN_INSTALL` to the agent container, following the same pattern as `GOROOT`, `CARGO_HOME`, and `JAVA_HOME`
- In `entrypoint.sh`, add `$BUN_INSTALL/bin` to PATH and export `BUN_INSTALL` in the chroot script
- Bun should be pre-installed on the host via `oven-sh/setup-bun` action, not installed inside the chroot

## Changes

- `src/docker-manager.ts` — Pass `process.env.BUN_INSTALL` as `AWF_BUN_INSTALL` env var
- `containers/agent/entrypoint.sh` — Add `BUN_INSTALL/bin` to PATH in chroot script (same pattern as Cargo/Java/Go)
- `src/docker-manager.test.ts` — Add tests for `AWF_BUN_INSTALL` passthrough

## Test plan

- [x] `npm run build` compiles
- [x] `npm test` — 729 unit tests pass (including 2 new tests)
- [x] `npm run lint` — no errors
- [ ] Verify `bun --version` works in chroot when `BUN_INSTALL` is set on host

🤖 Generated with [Claude Code](https://claude.com/claude-code)