### PR TITLE
fix: ensure .copilot directory permissions before Copilot CLI install

### DIFF
--- a/.github/workflows/smoke-chroot.lock.yml
+++ b/.github/workflows/smoke-chroot.lock.yml
@@ -191,6 +191,10 @@ jobs:
         run: /opt/gh-aw/actions/validate_multi_secret.sh COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      - name: Ensure .copilot directory permissions
+        run: |
+          mkdir -p /home/runner/.copilot
+          sudo chown -R runner:runner /home/runner/.copilot
       - name: Install GitHub Copilot CLI
         run: /opt/gh-aw/actions/install_copilot_cli.sh 0.0.402
       - name: Install awf binary
@@ -959,6 +963,10 @@ jobs:
         run: /opt/gh-aw/actions/validate_multi_secret.sh COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      - name: Ensure .copilot directory permissions
+        run: |
+          mkdir -p /home/runner/.copilot
+          sudo chown -R runner:runner /home/runner/.copilot
       - name: Install GitHub Copilot CLI
         run: /opt/gh-aw/actions/install_copilot_cli.sh 0.0.402
       - name: Execute GitHub Copilot CLI

--- a/.github/workflows/smoke-chroot.md
+++ b/.github/workflows/smoke-chroot.md
@@ -153,6 +153,10 @@ steps:
     if: always()
     run: |
       ./scripts/ci/cleanup.sh || true
+  - name: Ensure .copilot directory permissions
+    run: |
+      mkdir -p /home/runner/.copilot
+      sudo chown -R runner:runner /home/runner/.copilot
 ---
 
 # Analyze Chroot Test Results


### PR DESCRIPTION
## Summary

- Smoke Chroot workflow has been failing since the #541 revert with `EACCES: permission denied, mkdir '/home/runner/.copilot/pkg'`
- The chroot version tests run with `sudo -E awf` which can create `/home/runner/.copilot` as root. The subsequent Copilot CLI install (running as `runner` user) then fails to create subdirectories.
- Add `mkdir -p /home/runner/.copilot && sudo chown -R runner:runner /home/runner/.copilot` before the Copilot CLI install step in both the `.md` source and `.lock.yml`

## Test plan

- [ ] Smoke Chroot CI passes on this PR (the Copilot CLI install step should succeed)
- [x] All other CI checks pass (build, lint, tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

/cc @copilot for review