### PR TITLE
fix: hide /tmp/gh-aw/mcp-config/ from agent containers

### DIFF
--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -718,17 +718,22 @@ export function generateDockerCompose(
     dns_search: [], // Disable DNS search domains to prevent embedded DNS fallback
     volumes: agentVolumes,
     environment,
-    // Hide /tmp/gh-aw/mcp-logs directory using tmpfs (empty in-memory filesystem)
-    // This prevents the agent from accessing MCP server logs while still allowing
-    // the host to write logs to /tmp/gh-aw/mcp-logs/ (e.g., /tmp/gh-aw/mcp-logs/safeoutputs/)
-    // For normal mode: hide /tmp/gh-aw/mcp-logs
-    // For chroot mode: hide both /tmp/gh-aw/mcp-logs and /host/tmp/gh-aw/mcp-logs
+    // Hide /tmp/gh-aw/mcp-logs and /tmp/gh-aw/mcp-config directories using tmpfs
+    // (empty in-memory filesystems) to prevent the agent from accessing MCP server
+    // logs and configuration (which may contain tokens/credentials).
+    // For normal mode: hide /tmp/gh-aw/mcp-logs and /tmp/gh-aw/mcp-config
+    // For chroot mode: hide both paths and their /host/ equivalents
     tmpfs: config.enableChroot
       ? [
           '/tmp/gh-aw/mcp-logs:rw,noexec,nosuid,size=1m',
           '/host/tmp/gh-aw/mcp-logs:rw,noexec,nosuid,size=1m',
+          '/tmp/gh-aw/mcp-config:rw,noexec,nosuid,size=1m',
+          '/host/tmp/gh-aw/mcp-config:rw,noexec,nosuid,size=1m',
         ]
-      : ['/tmp/gh-aw/mcp-logs:rw,noexec,nosuid,size=1m'],
+      : [
+          '/tmp/gh-aw/mcp-logs:rw,noexec,nosuid,size=1m',
+          '/tmp/gh-aw/mcp-config:rw,noexec,nosuid,size=1m',
+        ],
     depends_on: {
       'squid-proxy': {
         condition: 'service_healthy',


### PR DESCRIPTION
## Summary

Addresses CVE-003 from #197 (MCP Server Compromise Test Results).

PR #706 hid `/tmp/gh-aw/mcp-logs/` from agent containers using tmpfs overlay mounts, but missed `/tmp/gh-aw/mcp-config/`, which may contain MCP server configuration files with tokens and credentials. A compromised MCP server or prompt injection attack could read these files to exfiltrate secrets.

This PR adds the same tmpfs hiding pattern for `/tmp/gh-aw/mcp-config/` in both normal and chroot modes, making the directory appear empty inside the agent container.

### Changes
- Add tmpfs mounts for `/tmp/gh-aw/mcp-config` (normal mode) and `/host/tmp/gh-aw/mcp-config` (chroot mode) alongside the existing mcp-logs mounts

### Issue #197 Pentest Findings Status
| Finding | Status |
|---------|--------|
| CVE-001: API key via `/proc/1/environ` | Already mitigated (one-shot-token LD_PRELOAD) |
| CVE-002: HTTP/HTTPS exfiltration | Already mitigated (Squid proxy domain filtering) |
| **CVE-003: MCP config directory exposed** | **Fixed in this PR** |
| CVE-004: DNS tunneling | Partially mitigated (`--dns-servers` restriction) |

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (743 tests)
- [x] `npm run lint` passes (0 errors)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)