### PR TITLE
fix: expand credential hiding list for runner tokens and MCP config

### DIFF
--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -318,6 +318,7 @@ export function generateDockerCompose(
     'SUDO_USER',      // Sudo metadata
     'SUDO_UID',       // Sudo metadata
     'SUDO_GID',       // Sudo metadata
+    'GH_AW_MCP_CONFIG', // Points to MCP config path containing auth tokens
   ]);
 
   // Start with required/overridden environment variables
@@ -666,6 +667,13 @@ export function generateDockerCompose(
       `${effectiveHome}/.kube/config`,
       `${effectiveHome}/.azure/credentials`,
       `${effectiveHome}/.config/gcloud/credentials.db`,
+      // GitHub Actions runner credentials (JWT tokens, RSA keys)
+      `${effectiveHome}/actions-runner/.credentials`,
+      `${effectiveHome}/actions-runner/.credentials_rsaparams`,
+      `${effectiveHome}/actions-runner/cached/.credentials`,
+      `${effectiveHome}/actions-runner/cached/.credentials_rsaparams`,
+      // MCP configuration (contains authorization tokens)
+      `${effectiveHome}/.copilot/mcp-config.json`,
     ];
 
     credentialFiles.forEach(credFile => {
@@ -697,6 +705,13 @@ export function generateDockerCompose(
       `/dev/null:/host${userHome}/.kube/config:ro`,
       `/dev/null:/host${userHome}/.azure/credentials:ro`,
       `/dev/null:/host${userHome}/.config/gcloud/credentials.db:ro`,
+      // GitHub Actions runner credentials (JWT tokens, RSA keys)
+      `/dev/null:/host${userHome}/actions-runner/.credentials:ro`,
+      `/dev/null:/host${userHome}/actions-runner/.credentials_rsaparams:ro`,
+      `/dev/null:/host${userHome}/actions-runner/cached/.credentials:ro`,
+      `/dev/null:/host${userHome}/actions-runner/cached/.credentials_rsaparams:ro`,
+      // MCP configuration (contains authorization tokens)
+      `/dev/null:/host${userHome}/.copilot/mcp-config.json:ro`,
     ];
 
     chrootCredentialFiles.forEach(mount => {


### PR DESCRIPTION
## Summary

Expands the credential file hiding list to cover missing sensitive files that were reported in multiple security issues:

- **GitHub Actions Runner credentials**: `.credentials`, `.credentials_rsaparams`, and their `cached/` variants — these contain JWT tokens and RSA key parameters
- **MCP configuration**: `.copilot/mcp-config.json` — contains authorization tokens for MCP servers
- **Environment variable**: Excludes `GH_AW_MCP_CONFIG` from `--env-all` passthrough to prevent trivial discovery of the MCP config file path

All paths are hidden via `/dev/null` mounts in both normal mode and chroot mode, following the same pattern as the existing 13+ credential files.

Closes #66, closes #179, closes #182, closes #195, closes #202, closes #208, closes #217, closes #218

## Changes

- `src/docker-manager.ts`: Added 5 new credential file paths to both normal and chroot mode lists; added `GH_AW_MCP_CONFIG` to `EXCLUDED_ENV_VARS`
- `src/docker-manager.test.ts`: Added 5 new tests covering runner credentials, MCP config hiding in both modes, and env var exclusion

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 748 tests pass (including 5 new ones)
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)