### PR TITLE
fix: upgrade gpgv in squid container to address CVE-2025-68973

### DIFF
--- a/containers/squid/Dockerfile
+++ b/containers/squid/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu/squid:latest
 RUN set -eux; \
     PKGS="curl dnsutils net-tools netcat-openbsd openssl squid-openssl"; \
     apt-get update && \
+    apt-get install -y --only-upgrade gpgv && \
     ( apt-get install -y --no-install-recommends $PKGS || \
       (rm -rf /var/lib/apt/lists/* && apt-get update && \
        apt-get install -y --no-install-recommends $PKGS) ) && \


### PR DESCRIPTION
## Summary
- Upgrades `gpgv` in the squid container Dockerfile to address CVE-2025-68973 (information disclosure and potential arbitrary code execution via out-of-bounds write)
- The base image ships `gpgv 2.4.4-2ubuntu17.3`; this adds an explicit `apt-get install -y --only-upgrade gpgv` step to pull the patched version (`2.4.4-2ubuntu17.4`+)
- The upgrade runs after `apt-get update` and before the existing package install, within the same RUN layer

## Test plan
- [ ] Verify the squid container builds successfully with `docker build containers/squid/`
- [ ] Confirm `gpgv` version inside the built container is `>= 2.4.4-2ubuntu17.4`
- [ ] Run integration tests to ensure firewall functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)