### PR TITLE
fix: upgrade packages in agent container to mitigate CVE-2023-44487

### DIFF
--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -33,6 +33,10 @@ RUN set -eux; \
     fi && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade all packages to pick up security patches
+# Addresses CVE-2023-44487 (HTTP/2 Rapid Reset) and other known vulnerabilities
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user with UID/GID matching host user
 # This allows the user command to run with appropriate permissions
 # and prevents file ownership issues with mounted volumes


### PR DESCRIPTION
## Summary

- Adds an `apt-get upgrade -y` step in the agent container Dockerfile after the main package installation to pick up all available security patches
- Addresses CVE-2023-44487 (HTTP/2 Rapid Reset Attack) affecting the `nodejs` package (22.22.0-1nodesource1) in the agent container
- While this CVE primarily affects HTTP/2 server implementations and the agent container acts as a client, upgrading is the recommended defense-in-depth approach

## Test plan

- [ ] Verify agent container builds successfully with the upgrade step
- [ ] Run integration tests to confirm no regressions
- [ ] Rebuild container image and verify with `trivy image` that CVE-2023-44487 is resolved or mitigated

🤖 Generated with [Claude Code](https://claude.com/claude-code)