### PR TITLE
fix: replace unanchored regex with string assertions in tests

### DIFF
--- a/src/squid-config.test.ts
+++ b/src/squid-config.test.ts
@@ -61,7 +61,7 @@ describe('generateSquidConfig', () => {
       };
       const result = generateSquidConfig(config);
       expect(result).toContain('acl allowed_domains dstdomain .github.com');
-      expect(result).not.toMatch(/github\.com\//);
+      expect(result).not.toContain('github.com/');
     });
 
     it('should remove trailing slash with protocol prefix', () => {
@@ -72,7 +72,7 @@ describe('generateSquidConfig', () => {
       const result = generateSquidConfig(config);
       expect(result).toContain('acl allowed_https_only dstdomain .example.com');
       expect(result).not.toContain('https://');
-      expect(result).not.toMatch(/example\.com\//);
+      expect(result).not.toContain('example.com/');
     });
 
     it('should handle domain with port number', () => {


### PR DESCRIPTION
## Summary

- Replace `.not.toMatch(/github\.com\//)` and `.not.toMatch(/example\.com\//)` with `.not.toContain('github.com/')` and `.not.toContain('example.com/')` in `src/squid-config.test.ts`
- Resolves CodeQL alerts #171 and #172 ("Missing regular expression anchor")
- Using `toContain` is semantically clearer since these tests verify that trailing slashes are stripped from domain strings, not that a regex pattern is absent

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (all 19 test suites)
- [x] No behavioral change — both assertions check for the same literal substring

🤖 Generated with [Claude Code](https://claude.com/claude-code)