### PR TITLE
feat(ci): add api-proxy image to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,37 @@ jobs:
             --type spdxjson \
             ghcr.io/${{ github.repository }}/agent@${{ steps.build_agent.outputs.digest }}
 
+      - name: Build and push API Proxy image
+        id: build_api_proxy
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: ./containers/api-proxy
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/api-proxy:${{ steps.version_early.outputs.version_number }}
+            ghcr.io/${{ github.repository }}/api-proxy:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign API Proxy image with cosign
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ github.repository }}/api-proxy@${{ steps.build_api_proxy.outputs.digest }}
+
+      - name: Generate SBOM for API Proxy image
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
+        with:
+          image: ghcr.io/${{ github.repository }}/api-proxy@${{ steps.build_api_proxy.outputs.digest }}
+          format: spdx-json
+          output-file: api-proxy-sbom.spdx.json
+
+      - name: Attest SBOM for API Proxy image
+        run: |
+          cosign attest --yes \
+            --predicate api-proxy-sbom.spdx.json \
+            --type spdxjson \
+            ghcr.io/${{ github.repository }}/api-proxy@${{ steps.build_api_proxy.outputs.digest }}
+
       # Build agent-act image with catthehacker/ubuntu:act-24.04 base for GitHub Actions parity
       - name: Build and push Agent-Act image
         id: build_agent_act

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/agentic-workflow-firewall",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/agentic-workflow-firewall",
-      "version": "0.16.4",
+      "version": "0.16.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/agentic-workflow-firewall",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Network firewall for agentic workflows with domain whitelisting",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Add build, push, cosign signing, and SBOM attestation steps for the `api-proxy` container image to the release workflow

## Context

The `containers/api-proxy/` directory has existed in this repo since #751, but the release workflow only builds and pushes `squid`, `agent`, and `agent-act` images. The `api-proxy` image was never published to GHCR.

This causes failures in gh-aw workflows that use `--enable-api-proxy`:
```
Container awf-api-proxy  Error response from daemon: No such image:
ghcr.io/github/gh-aw-firewall/api-proxy:0.16.5
```

See: https://github.com/github/gh-aw/pull/15533 (gh-aw side that enables `--enable-api-proxy` for Claude and Codex)

## Changes

Added to `release.yml` between the Agent and Agent-Act image steps:
1. **Build and push** API Proxy image (with GHA cache)
2. **Sign** with cosign
3. **Generate SBOM** with anchore/sbom-action
4. **Attest SBOM** with cosign

Follows the exact same pattern as the squid and agent image steps.

## Test plan

- [ ] After merge, cut a new release and verify `ghcr.io/github/gh-aw-firewall/api-proxy:<version>` is published
- [ ] Run smoke-claude and smoke-codex with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)