### PR TITLE
chore: reduce dependabot PR volume to ~5/week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 # Dependabot configuration for automated dependency updates
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# PR budget: ~5 total across all ecosystems (2 + 1 + 1 + 1 = 5)
+# Each ecosystem groups ALL deps into a single PR to minimize noise.
 
 version: 2
 updates:
@@ -9,30 +12,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     groups:
-      # Group TypeScript-related dependencies
-      typescript:
+      all-npm-dependencies:
         patterns:
-          - "typescript"
-          - "@types/*"
-          - "@typescript-eslint/*"
-          - "ts-*"
-      # Group testing dependencies
-      testing:
-        patterns:
-          - "jest"
-          - "*jest*"
-      # Group linting dependencies
-      linting:
-        patterns:
-          - "eslint"
-          - "*eslint*"
-      # Group commit-related dependencies
-      commitlint:
-        patterns:
-          - "@commitlint/*"
-          - "husky"
+          - "*"
 
   # npm ecosystem - docs-site
   - package-ecosystem: "npm"
@@ -40,13 +24,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
-      # Group Astro-related dependencies
-      astro:
+      all-docs-site-dependencies:
         patterns:
-          - "astro"
-          - "@astrojs/*"
+          - "*"
 
   # Docker ecosystem - agent container
   - package-ecosystem: "docker"
@@ -54,7 +36,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
+    groups:
+      all-docker-agent:
+        patterns:
+          - "*"
 
   # Docker ecosystem - squid container
   - package-ecosystem: "docker"
@@ -62,7 +48,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
+    groups:
+      all-docker-squid:
+        patterns:
+          - "*"
 
   # GitHub Actions ecosystem
   - package-ecosystem: "github-actions"
@@ -70,9 +60,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
-      # Group GitHub official actions
-      github-actions:
+      all-github-actions:
         patterns:
-          - "actions/*"
+          - "*"


### PR DESCRIPTION
## Summary

- Group all dependencies within each ecosystem into single PRs using wildcard `"*"` patterns
- Reduce `open-pull-requests-limit` across all ecosystems: npm root (10→2), docs-site (5→1), docker agent (2→1), docker squid (2→1), github-actions (5→1)
- Total max: 6 open PRs (down from 24), typically ≤5 in practice since not every ecosystem updates weekly

## Test plan

- [ ] Verify dependabot creates grouped PRs on next Monday schedule
- [ ] Confirm total open dependabot PRs stays ≤5

🤖 Generated with [Claude Code](https://claude.com/claude-code)