### PR TITLE
feat: set NO_COLOR=1 in agent container environment

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -494,6 +494,14 @@ describe('docker-manager', () => {
       expect(env.SQUID_PROXY_PORT).toBe('3128');
     });
 
+    it('should set NO_COLOR=1 to disable ANSI color output from CLI tools', () => {
+      const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+      const agent = result.services.agent;
+      const env = agent.environment as Record<string, string>;
+
+      expect(env.NO_COLOR).toBe('1');
+    });
+
     it('should mount required volumes in agent container (default behavior)', () => {
       const result = generateDockerCompose(mockConfig, mockNetworkConfig);
       const agent = result.services.agent;

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -347,6 +347,10 @@ export function generateDockerCompose(
     SQUID_PROXY_PORT: SQUID_PORT.toString(),
     HOME: homeDir,
     PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    // Disable ANSI color output from CLI tools (Rich, Chalk, etc.) inside the container.
+    // Tools like Rich inject ANSI escape codes that break test assertions expecting plain text.
+    // NO_COLOR is a standard convention (https://no-color.org/) supported by many libraries.
+    NO_COLOR: '1',
     // Configure one-shot-token library with sensitive tokens to protect
     // These tokens are cached on first access and unset from /proc/self/environ
     AWF_ONE_SHOT_TOKENS: 'COPILOT_GITHUB_TOKEN,GITHUB_TOKEN,GH_TOKEN,GITHUB_API_TOKEN,GITHUB_PAT,GH_ACCESS_TOKEN,OPENAI_API_KEY,OPENAI_KEY,ANTHROPIC_API_KEY,CLAUDE_API_KEY,CODEX_API_KEY',


### PR DESCRIPTION
## Summary

- Adds `NO_COLOR=1` to the base agent container environment in `docker-manager.ts`
- This disables ANSI color escape codes from CLI tools (Rich, Chalk, etc.) inside the container
- Adds a unit test to `docker-manager.test.ts` verifying the env var is set

## Problem

The python/typer test suite has 150 failures because the Rich library injects ANSI escape codes into CLI help output. Tests expect plain text like `"Usage: custom-name [OPTIONS]"` but get `"Usage: \x1b[0m\x1b[1mcustom-name [OPTIONS]\x1b[0m"`.

## Solution

`NO_COLOR` is a standard convention ([no-color.org](https://no-color.org/)) supported by many libraries including Rich (Python), Chalk (Node.js), and others. Setting `NO_COLOR=1` in the container environment tells all compliant tools to disable color output.

The env var is added to the base `environment` object (alongside `HTTP_PROXY`, `HOME`, etc.) so it is always set before `--env-all` expansion. Since `--env-all` skips keys already in `environment`, users cannot accidentally override it with a host `NO_COLOR=0`.

## Test plan

- [x] All 794 existing unit tests pass (`npm test`)
- [x] New test added: `should set NO_COLOR=1 to disable ANSI color output from CLI tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)