### PR TITLE
docs: add releasing.md link to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This is a firewall for GitHub Copilot CLI (package name: `@github/awf`) that pro
 - **[docs/environment.md](docs/environment.md)** - Environment variable configuration and security best practices
 - **[LOGGING.md](LOGGING.md)** - Comprehensive logging documentation
 - **[docs/logging_quickref.md](docs/logging_quickref.md)** - Quick reference for log queries and monitoring
+- **[docs/releasing.md](docs/releasing.md)** - Release process and versioning instructions
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- Added a link to `docs/releasing.md` in the Documentation Files section of CLAUDE.md so agents can discover the release process instructions.

## Test plan
- [x] Verify the link path is correct relative to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)