### PR TITLE
fix: prevent agent from accessing host git credentials

### DIFF
--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -351,6 +351,9 @@ export function generateDockerCompose(
     // Tools like Rich inject ANSI escape codes that break test assertions expecting plain text.
     // NO_COLOR is a standard convention (https://no-color.org/) supported by many libraries.
     NO_COLOR: '1',
+    // SECURITY: Prevent git from prompting for credentials interactively.
+    // This stops credential helpers from being invoked via terminal prompts.
+    GIT_TERMINAL_PROMPT: '0',
     // Configure one-shot-token library with sensitive tokens to protect
     // These tokens are cached on first access and unset from /proc/self/environ
     AWF_ONE_SHOT_TOKENS: 'COPILOT_GITHUB_TOKEN,GITHUB_TOKEN,GH_TOKEN,GITHUB_API_TOKEN,GITHUB_PAT,GH_ACCESS_TOKEN,OPENAI_API_KEY,OPENAI_KEY,ANTHROPIC_API_KEY,CLAUDE_API_KEY,CODEX_API_KEY',
@@ -757,6 +760,13 @@ export function generateDockerCompose(
       `${effectiveHome}/.cargo/credentials`,        // Rust crates.io tokens
       `${effectiveHome}/.composer/auth.json`,       // PHP Composer tokens
       `${effectiveHome}/.config/gh/hosts.yml`,      // GitHub CLI OAuth tokens
+      // Git credentials (CRITICAL - repository access, API token extraction)
+      // Agents can extract tokens from git config and use them for unauthorized API calls
+      // (e.g., creating PRs via curl with stolen AUTHORIZATION headers)
+      `${effectiveHome}/.gitconfig`,                // Git global config (may contain credential helpers or extraheader tokens)
+      `${effectiveHome}/.git-credentials`,          // Git credential store (plaintext tokens: https://user:TOKEN@host)
+      `${effectiveHome}/.config/git/config`,        // Git XDG config (may contain credential helpers or extraheader tokens)
+      `${effectiveHome}/.config/git/credentials`,   // Git XDG credential store (plaintext tokens)
       // SSH private keys (CRITICAL - server access, git operations)
       `${effectiveHome}/.ssh/id_rsa`,
       `${effectiveHome}/.ssh/id_ed25519`,
@@ -789,6 +799,11 @@ export function generateDockerCompose(
       `/dev/null:/host${effectiveHome}/.cargo/credentials:ro`,
       `/dev/null:/host${effectiveHome}/.composer/auth.json:ro`,
       `/dev/null:/host${effectiveHome}/.config/gh/hosts.yml:ro`,
+      // Git credentials (CRITICAL - repository access, API token extraction)
+      `/dev/null:/host${effectiveHome}/.gitconfig:ro`,
+      `/dev/null:/host${effectiveHome}/.git-credentials:ro`,
+      `/dev/null:/host${effectiveHome}/.config/git/config:ro`,
+      `/dev/null:/host${effectiveHome}/.config/git/credentials:ro`,
       // SSH private keys (CRITICAL - server access, git operations)
       `/dev/null:/host${effectiveHome}/.ssh/id_rsa:ro`,
       `/dev/null:/host${effectiveHome}/.ssh/id_ed25519:ro`,


### PR DESCRIPTION
## Summary

- Block git credential files (`.gitconfig`, `.git-credentials`, `.config/git/config`, `.config/git/credentials`) via `/dev/null` mounts to prevent agents from extracting tokens
- Sanitize workspace `.git/config` at container startup to strip `extraheader` entries containing `AUTHORIZATION` tokens set by `actions/checkout`
- Disable git credential helpers globally and set `GIT_TERMINAL_PROMPT=0`

## Security Issue

Agents running inside the AWF container can access the host's git credentials through multiple vectors:

1. **Git credential files** exposed via the `~/.config` mount (`~/.config/git/credentials`, `~/.config/git/config`)
2. **Workspace `.git/config`** containing `http.*.extraheader` with auth tokens set by `actions/checkout`

In the wild, agents have been observed extracting these tokens and using `curl` to make direct GitHub API calls (e.g., creating PRs) — bypassing intended access controls. Example: https://github.com/phpstan/phpstan/actions/runs/22106856182

## Changes

### `src/docker-manager.ts`
- Added 4 git credential files to both `credentialFiles` and `chrootCredentialFiles` arrays for `/dev/null` overlay blocking
- Added `GIT_TERMINAL_PROMPT=0` to the container environment

### `containers/agent/entrypoint.sh`
- Added git credential sanitization after safe directory config:
  1. Disables credential helpers globally for `awfuser`
  2. Strips all `http.*.extraheader` entries from workspace `.git/config`
  3. Removes `credential.helper` entries from workspace `.git/config`

### `tests/integration/credential-hiding.test.ts`
- Added 8 new integration tests (Tests 15-22) covering git credential hiding
- Tests verify: XDG git config/credentials hidden, `.gitconfig`/`.git-credentials` hidden, `git credential fill` returns empty, chroot path hiding, debug log verification

## Test plan

- [x] Unit tests pass (795/795)
- [x] Lint passes (0 errors)
- [ ] Integration tests for git credential hiding (Tests 15-22)
- [ ] Existing credential hiding tests still pass (Tests 1-14)
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)