### PR TITLE
feat(proxy): make copilot api target configurable for enterprise envi…

### DIFF
--- a/containers/api-proxy/README.md
+++ b/containers/api-proxy/README.md
@@ -35,6 +35,9 @@ Required (at least one):
 - `OPENAI_API_KEY` - OpenAI API key for authentication
 - `ANTHROPIC_API_KEY` - Anthropic API key for authentication
 
+Optional:
+- `COPILOT_API_TARGET` - Target hostname for GitHub Copilot API requests (default: `api.githubcopilot.com`). Useful for GHES deployments.
+
 Set by AWF:
 - `HTTP_PROXY` - Squid proxy URL (http://172.30.0.10:3128)
 - `HTTPS_PROXY` - Squid proxy URL (http://172.30.0.10:3128)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -785,6 +785,12 @@ program
     false
   )
   .option(
+    '--copilot-api-target <host>',
+    'Target hostname for GitHub Copilot API requests in the api-proxy sidecar.\n' +
+    '                                   Defaults to api.githubcopilot.com. Useful for GHES deployments.\n' +
+    '                                   Can also be set via COPILOT_API_TARGET env var.',
+  )
+  .option(
     '--rate-limit-rpm <n>',
     'Enable rate limiting: max requests per minute per provider (requires --enable-api-proxy)',
   )
@@ -1064,6 +1070,7 @@ program
       openaiApiKey: process.env.OPENAI_API_KEY,
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
       copilotGithubToken: process.env.COPILOT_GITHUB_TOKEN,
+      copilotApiTarget: options.copilotApiTarget || process.env.COPILOT_API_TARGET,
     };
 
     // Build rate limit config when API proxy is enabled

--- a/src/types.ts
+++ b/src/types.ts
@@ -472,6 +472,28 @@ export interface WrapperConfig {
    * @default undefined
    */
   copilotGithubToken?: string;
+
+  /**
+   * Target hostname for GitHub Copilot API requests (used by API proxy sidecar)
+   *
+   * When enableApiProxy is true, this hostname is passed to the Node.js sidecar
+   * as `COPILOT_API_TARGET`. The proxy will forward Copilot API requests to this host
+   * instead of the default `api.githubcopilot.com`.
+   *
+   * Useful for GitHub Enterprise Server (GHES) deployments where the Copilot API
+   * endpoint differs from the public default.
+   *
+   * Can be set via:
+   * - CLI flag: `--copilot-api-target <host>`
+   * - Environment variable: `COPILOT_API_TARGET`
+   *
+   * @default 'api.githubcopilot.com'
+   * @example
+   * ```bash
+   * awf --enable-api-proxy --copilot-api-target api.github.mycompany.com -- command
+   * ```
+   */
+  copilotApiTarget?: string;
 }
 
 /**


### PR DESCRIPTION
…ronments

Auto-derive api.enterprise.githubcopilot.com from GITHUB_SERVER_URL when the server is not github.com (GHEC/GHES). Allow explicit override via COPILOT_API_TARGET env var or --copilot-api-target CLI flag. Forward GITHUB_SERVER_URL and GITHUB_API_URL to both agent and api-proxy containers by default.