### PR TITLE
fix: use docker cp instead of file bind mounts for DinD compatibility

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -2284,7 +2284,7 @@ describe('docker-manager', () => {
       expect(mockExecaFn).toHaveBeenCalledWith(
         'docker',
         ['compose', 'up', '-d'],
-        { cwd: testDir, stdio: 'inherit' }
+        { cwd: testDir, stdout: process.stderr, stderr: 'inherit' }
       );
     });
 
@@ -2297,7 +2297,7 @@ describe('docker-manager', () => {
       expect(mockExecaFn).toHaveBeenCalledWith(
         'docker',
         ['compose', 'up', '-d'],
-        { cwd: testDir, stdio: 'inherit' }
+        { cwd: testDir, stdout: process.stderr, stderr: 'inherit' }
       );
     });
 
@@ -2310,7 +2310,7 @@ describe('docker-manager', () => {
       expect(mockExecaFn).toHaveBeenCalledWith(
         'docker',
         ['compose', 'up', '-d', '--pull', 'never'],
-        { cwd: testDir, stdio: 'inherit' }
+        { cwd: testDir, stdout: process.stderr, stderr: 'inherit' }
       );
     });
 
@@ -2323,7 +2323,7 @@ describe('docker-manager', () => {
       expect(mockExecaFn).toHaveBeenCalledWith(
         'docker',
         ['compose', 'up', '-d'],
-        { cwd: testDir, stdio: 'inherit' }
+        { cwd: testDir, stdout: process.stderr, stderr: 'inherit' }
       );
     });
 
@@ -2378,7 +2378,7 @@ describe('docker-manager', () => {
       expect(mockExecaFn).toHaveBeenCalledWith(
         'docker',
         ['compose', 'down', '-v'],
-        { cwd: testDir, stdio: 'inherit' }
+        { cwd: testDir, stdout: process.stderr, stderr: 'inherit' }
       );
     });
 

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -1425,9 +1425,16 @@ export async function startContainers(workDir: string, allowedDomains: string[],
       composeArgs.push('--pull', 'never');
       logger.debug('Using --pull never (skip-pull mode)');
     }
+    // Redirect Docker Compose stdout to stderr so it doesn't pollute the
+    // agent command's stdout. Docker Compose outputs build progress and
+    // container creation status to stdout, which would be captured by test
+    // runners and break assertions that check for agent command output.
+    // All AWF informational output goes to stderr (via logger), so this
+    // keeps the output consistent. Users still see progress in their terminal.
     await execa('docker', composeArgs, {
       cwd: workDir,
-      stdio: 'inherit',
+      stdout: process.stderr,
+      stderr: 'inherit',
     });
     logger.success('Containers started successfully');
   } catch (error) {
@@ -1581,7 +1588,8 @@ export async function stopContainers(workDir: string, keepContainers: boolean): 
   try {
     await execa('docker', ['compose', 'down', '-v'], {
       cwd: workDir,
-      stdio: 'inherit',
+      stdout: process.stderr,
+      stderr: 'inherit',
     });
     logger.success('Containers stopped successfully');
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #18385 (github/gh-aw#18385)

Three fixes in this PR:

1. **DinD compatibility**: Replace squid.conf file bind mount with base64-encoded environment variable injection
2. **Dependency audit**: Fix npm audit vulnerabilities (ajv ReDoS, minimatch ReDoS)  
3. **Test reliability**: Redirect Docker Compose stdout to stderr to prevent build output from polluting test assertions

### Fix 1: DinD squid.conf injection

In DinD, the Docker daemon runs in a separate `dind` sidecar container. File bind mounts fail because the daemon can't access files on the runner's filesystem. Instead of bind-mounting `squid.conf`, the config is:
1. Base64-encoded and passed as `AWF_SQUID_CONFIG_B64` env var
2. Decoded by an entrypoint override before squid starts

### Fix 2: Dependency vulnerabilities

`npm audit fix` resolves:
- `ajv` <6.14.0: moderate severity ReDoS with `$data` option
- `minimatch` 10.0.0-10.2.2: high severity ReDoS via GLOBSTAR segments

### Fix 3: Docker Compose stdout isolation

Docker Compose outputs build progress and container status to stdout during `docker compose up -d`. When integration tests capture AWF's stdout, this build output gets mixed in, breaking test assertions. Fixed by redirecting Docker Compose stdout to `process.stderr`, keeping it visible to users while isolating agent command output for tests.

### Changes

- **`src/docker-manager.ts`**: env var injection, entrypoint override, YAML lineWidth fix, stdout→stderr redirect
- **`src/docker-manager.test.ts`**: updated test expectations
- **`package-lock.json`**: npm audit fix

## Test plan

- [x] All 822 unit tests pass
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint` — 0 errors)
- [x] `npm audit` — 0 vulnerabilities
- [ ] CI integration tests (monitoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)