### PR TITLE
fix(docker): disable IPv6 when ip6tables unavailable

### DIFF
--- a/containers/agent/setup-iptables.sh
+++ b/containers/agent/setup-iptables.sh
@@ -32,7 +32,9 @@ if has_ip6tables; then
   IP6TABLES_AVAILABLE=true
   echo "[iptables] ip6tables is available"
 else
-  echo "[iptables] WARNING: ip6tables is not available, IPv6 rules will be skipped"
+  echo "[iptables] WARNING: ip6tables is not available, disabling IPv6 via sysctl to prevent unfiltered bypass"
+  sysctl -w net.ipv6.conf.all.disable_ipv6=1 2>/dev/null || echo "[iptables] WARNING: failed to disable IPv6 (net.ipv6.conf.all.disable_ipv6)"
+  sysctl -w net.ipv6.conf.default.disable_ipv6=1 2>/dev/null || echo "[iptables] WARNING: failed to disable IPv6 (net.ipv6.conf.default.disable_ipv6)"
 fi
 
 # Get Squid proxy configuration from environment

--- a/src/host-iptables.test.ts
+++ b/src/host-iptables.test.ts
@@ -1,4 +1,4 @@
-import { ensureFirewallNetwork, setupHostIptables, cleanupHostIptables, cleanupFirewallNetwork } from './host-iptables';
+import { ensureFirewallNetwork, setupHostIptables, cleanupHostIptables, cleanupFirewallNetwork, _resetIpv6State } from './host-iptables';
 import execa from 'execa';
 
 // Mock execa
@@ -19,6 +19,7 @@ jest.mock('./logger', () => ({
 describe('host-iptables', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    _resetIpv6State();
   });
 
   describe('ensureFirewallNetwork', () => {
@@ -490,6 +491,48 @@ describe('host-iptables', () => {
       ]);
     });
 
+    it('should disable IPv6 via sysctl when ip6tables unavailable', async () => {
+      // Make ip6tables unavailable
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: 'fw-bridge', stderr: '', exitCode: 0 } as any)
+        // iptables -L DOCKER-USER permission check
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any)
+        // chain existence check (doesn't exist)
+        .mockResolvedValueOnce({ exitCode: 1 } as any);
+
+      // All subsequent calls succeed (except ip6tables)
+      mockedExeca.mockImplementation(((cmd: string, _args: string[]) => {
+        if (cmd === 'ip6tables') {
+          return Promise.reject(new Error('ip6tables not found'));
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+      }) as any);
+
+      await setupHostIptables('172.30.0.10', 3128, ['8.8.8.8', '8.8.4.4']);
+
+      // Verify sysctl was called to disable IPv6
+      expect(mockedExeca).toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.all.disable_ipv6=1']);
+      expect(mockedExeca).toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.default.disable_ipv6=1']);
+    });
+
+    it('should not disable IPv6 via sysctl when ip6tables is available', async () => {
+      mockedExeca
+        // Mock getNetworkBridgeName
+        .mockResolvedValueOnce({ stdout: 'fw-bridge', stderr: '', exitCode: 0 } as any)
+        // Mock iptables -L DOCKER-USER (permission check)
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any)
+        // Mock chain existence check (doesn't exist)
+        .mockResolvedValueOnce({ exitCode: 1 } as any);
+
+      mockedExeca.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 } as any);
+
+      await setupHostIptables('172.30.0.10', 3128, ['8.8.8.8', '8.8.4.4']);
+
+      // Verify sysctl was NOT called to disable IPv6
+      expect(mockedExeca).not.toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.all.disable_ipv6=1']);
+      expect(mockedExeca).not.toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.default.disable_ipv6=1']);
+    });
+
     it('should not create IPv6 chain when no IPv6 DNS servers', async () => {
       mockedExeca
         // Mock getNetworkBridgeName
@@ -539,6 +582,39 @@ describe('host-iptables', () => {
       // Verify IPv6 chain cleanup operations
       expect(mockedExeca).toHaveBeenCalledWith('ip6tables', ['-t', 'filter', '-F', 'FW_WRAPPER_V6'], { reject: false });
       expect(mockedExeca).toHaveBeenCalledWith('ip6tables', ['-t', 'filter', '-X', 'FW_WRAPPER_V6'], { reject: false });
+    });
+
+    it('should re-enable IPv6 via sysctl on cleanup if it was disabled', async () => {
+      // First, simulate setup that disabled IPv6
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: 'fw-bridge', stderr: '', exitCode: 0 } as any)
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 } as any)
+        .mockResolvedValueOnce({ exitCode: 1 } as any);
+
+      // Make ip6tables unavailable to trigger sysctl disable
+      mockedExeca.mockImplementation(((cmd: string) => {
+        if (cmd === 'ip6tables') {
+          return Promise.reject(new Error('ip6tables not found'));
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+      }) as any);
+
+      await setupHostIptables('172.30.0.10', 3128, ['8.8.8.8']);
+
+      // Now run cleanup
+      jest.clearAllMocks();
+      mockedExeca.mockImplementation(((cmd: string) => {
+        if (cmd === 'ip6tables') {
+          return Promise.reject(new Error('ip6tables not found'));
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+      }) as any);
+
+      await cleanupHostIptables();
+
+      // Verify IPv6 was re-enabled via sysctl
+      expect(mockedExeca).toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.all.disable_ipv6=0']);
+      expect(mockedExeca).toHaveBeenCalledWith('sysctl', ['-w', 'net.ipv6.conf.default.disable_ipv6=0']);
     });
 
     it('should not throw on errors (best-effort cleanup)', async () => {

--- a/src/host-iptables.ts
+++ b/src/host-iptables.ts
@@ -11,6 +11,17 @@ const NETWORK_SUBNET = '172.30.0.0/24';
 // Cache for ip6tables availability check (only checked once per run)
 let ip6tablesAvailableCache: boolean | null = null;
 
+// Track whether IPv6 was disabled via sysctl (so we can re-enable on cleanup)
+let ipv6DisabledViaSysctl = false;
+
+/**
+ * Resets internal IPv6 state (for testing only).
+ */
+export function _resetIpv6State(): void {
+  ip6tablesAvailableCache = null;
+  ipv6DisabledViaSysctl = false;
+}
+
 /**
  * Gets the bridge interface name for the firewall network
  */
@@ -49,6 +60,38 @@ async function isIp6tablesAvailable(): Promise<boolean> {
     logger.debug('ip6tables not available:', error);
     ip6tablesAvailableCache = false;
     return false;
+  }
+}
+
+/**
+ * Disables IPv6 via sysctl when ip6tables is unavailable.
+ * This prevents IPv6 from becoming an unfiltered bypass path.
+ */
+async function disableIpv6ViaSysctl(): Promise<void> {
+  try {
+    await execa('sysctl', ['-w', 'net.ipv6.conf.all.disable_ipv6=1']);
+    await execa('sysctl', ['-w', 'net.ipv6.conf.default.disable_ipv6=1']);
+    ipv6DisabledViaSysctl = true;
+    logger.info('IPv6 disabled via sysctl (ip6tables unavailable)');
+  } catch (error) {
+    logger.warn('Failed to disable IPv6 via sysctl:', error);
+  }
+}
+
+/**
+ * Re-enables IPv6 via sysctl if it was previously disabled.
+ */
+async function enableIpv6ViaSysctl(): Promise<void> {
+  if (!ipv6DisabledViaSysctl) {
+    return;
+  }
+  try {
+    await execa('sysctl', ['-w', 'net.ipv6.conf.all.disable_ipv6=0']);
+    await execa('sysctl', ['-w', 'net.ipv6.conf.default.disable_ipv6=0']);
+    ipv6DisabledViaSysctl = false;
+    logger.debug('IPv6 re-enabled via sysctl');
+  } catch (error) {
+    logger.debug('Failed to re-enable IPv6 via sysctl:', error);
   }
 }
 
@@ -309,13 +352,17 @@ export async function setupHostIptables(squidIp: string, squidPort: number, dnsS
     ]);
   }
 
+  // Check ip6tables availability and disable IPv6 if unavailable
+  const ip6tablesAvailable = await isIp6tablesAvailable();
+  if (!ip6tablesAvailable) {
+    logger.warn('ip6tables is not available, disabling IPv6 via sysctl to prevent unfiltered bypass');
+    await disableIpv6ViaSysctl();
+  }
+
   // Add IPv6 DNS server rules using ip6tables
   if (ipv6DnsServers.length > 0) {
-    // Check if ip6tables is available before setting up IPv6 rules
-    const ip6tablesAvailable = await isIp6tablesAvailable();
     if (!ip6tablesAvailable) {
-      logger.warn('ip6tables is not available, IPv6 DNS servers will not be configured at the host level');
-      logger.warn('  IPv6 traffic may not be properly filtered');
+      logger.warn('IPv6 DNS servers configured but ip6tables not available; IPv6 has been disabled');
     } else {
       // Set up IPv6 chain if we have IPv6 DNS servers
       await setupIpv6Chain(bridgeName);
@@ -614,6 +661,10 @@ export async function cleanupHostIptables(): Promise<void> {
     } else {
       logger.debug('ip6tables not available, skipping IPv6 cleanup');
     }
+
+    // Re-enable IPv6 if it was disabled via sysctl
+    await enableIpv6ViaSysctl();
+
     logger.debug('Host-level iptables rules cleaned up');
   } catch (error) {
     logger.debug('Error cleaning up iptables rules:', error);


### PR DESCRIPTION
## Summary

Fixes #245

When `ip6tables` is not available, IPv6 traffic previously bypassed all firewall filtering rules. This PR:

- **Host-level** (`src/host-iptables.ts`): Disables IPv6 via `sysctl -w net.ipv6.conf.all.disable_ipv6=1` when ip6tables is unavailable, and re-enables on cleanup
- **Container-level** (`containers/agent/setup-iptables.sh`): Disables IPv6 via sysctl in the agent container when ip6tables is unavailable
- Adds unit tests verifying sysctl disable/re-enable behavior

## Test plan

- [x] Unit tests pass (824 tests, 0 failures)
- [x] Build succeeds
- [x] Lint passes (0 errors)
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)