### PR TITLE
fix(security): stop logging partial token values

### DIFF
--- a/containers/agent/one-shot-token/README.md
+++ b/containers/agent/one-shot-token/README.md
@@ -252,7 +252,7 @@ LD_PRELOAD=./one-shot-token.so ./test_getenv
 Expected output (with debug logging enabled):
 ```
 [one-shot-token] Initialized with 11 default token(s)
-[one-shot-token] Token GITHUB_TOKEN accessed and cached (value: test...)
+[one-shot-token] Token GITHUB_TOKEN accessed and cached (length: 16)
 [one-shot-token] INFO: Token GITHUB_TOKEN cleared from process environment
 First read: test-token-12345
 Second read: test-token-12345
@@ -283,11 +283,11 @@ LD_PRELOAD=./one-shot-token.so bash -c '
 Expected output (with debug logging enabled):
 ```
 [one-shot-token] Initialized with 2 custom token(s) from AWF_ONE_SHOT_TOKENS
-[one-shot-token] Token MY_API_KEY accessed and cached (value: secr...)
+[one-shot-token] Token MY_API_KEY accessed and cached (length: 16)
 [one-shot-token] INFO: Token MY_API_KEY cleared from process environment
 First MY_API_KEY: secret-value-123
 Second MY_API_KEY: secret-value-123
-[one-shot-token] Token SECRET_TOKEN accessed and cached (value: anot...)
+[one-shot-token] Token SECRET_TOKEN accessed and cached (length: 14)
 [one-shot-token] INFO: Token SECRET_TOKEN cleared from process environment
 First SECRET_TOKEN: another-secret
 Second SECRET_TOKEN: another-secret

--- a/containers/agent/one-shot-token/one-shot-token.c
+++ b/containers/agent/one-shot-token/one-shot-token.c
@@ -310,34 +310,6 @@ static int get_token_index(const char *name) {
 }
 
 /**
- * Format token value for logging: show first 4 characters + "..."
- * Returns a static buffer (not thread-safe for the buffer, but safe for our use case
- * since we hold token_mutex when calling this)
- */
-static const char *format_token_value(const char *value) {
-    static char formatted[8]; /* "abcd..." + null terminator */
-
-    if (value == NULL) {
-        return "NULL";
-    }
-
-    size_t len = strlen(value);
-    if (len == 0) {
-        return "(empty)";
-    }
-
-    if (len <= 4) {
-        /* If 4 chars or less, just show it all with ... */
-        snprintf(formatted, sizeof(formatted), "%s...", value);
-    } else {
-        /* Show first 4 chars + ... */
-        snprintf(formatted, sizeof(formatted), "%.4s...", value);
-    }
-
-    return formatted;
-}
-
-/**
  * Intercepted getenv function
  *
  * For sensitive tokens:
@@ -392,8 +364,8 @@ char *getenv(const char *name) {
             unsetenv(name);
 
             if (debug_enabled) {
-                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (value: %s)\n",
-                        name, format_token_value(token_cache[token_idx]));
+                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (length: %zu)\n",
+                        name, strlen(token_cache[token_idx]));
             }
 
             result = token_cache[token_idx];
@@ -458,8 +430,8 @@ char *secure_getenv(const char *name) {
             unsetenv(name);
 
             if (debug_enabled) {
-                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (value: %s) (via secure_getenv)\n",
-                        name, format_token_value(token_cache[token_idx]));
+                fprintf(stderr, "[one-shot-token] Token %s accessed and cached (length: %zu) (via secure_getenv)\n",
+                        name, strlen(token_cache[token_idx]));
             }
 
             result = token_cache[token_idx];

--- a/containers/agent/one-shot-token/src/lib.rs
+++ b/containers/agent/one-shot-token/src/lib.rs
@@ -232,19 +232,6 @@ fn is_sensitive_token(state: &TokenState, name: &str) -> bool {
     state.tokens.iter().any(|t| t == name)
 }
 
-/// Format token value for logging: show first 4 characters + "..."
-fn format_token_value(value: &str) -> String {
-    if value.is_empty() {
-        return "(empty)".to_string();
-    }
-
-    if value.len() <= 4 {
-        format!("{}...", value)
-    } else {
-        format!("{}...", &value[..4])
-    }
-}
-
 /// Check if a token still exists in the process environment
 ///
 /// This function verifies whether unsetenv() successfully cleared the token
@@ -381,8 +368,8 @@ unsafe fn handle_getenv_impl(
     if debug_enabled {
         let suffix = if via_secure { " (via secure_getenv)" } else { "" };
         eprintln!(
-            "[one-shot-token] Token {} accessed and cached (value: {}){}",
-            name_str, format_token_value(value_str), suffix
+            "[one-shot-token] Token {} accessed and cached (length: {}){}",
+            name_str, value_str.len(), suffix
         );
     }
 
@@ -446,12 +433,4 @@ mod tests {
         assert!(!state.initialized);
     }
 
-    #[test]
-    fn test_format_token_value() {
-        assert_eq!(format_token_value(""), "(empty)");
-        assert_eq!(format_token_value("ab"), "ab...");
-        assert_eq!(format_token_value("abcd"), "abcd...");
-        assert_eq!(format_token_value("abcde"), "abcd...");
-        assert_eq!(format_token_value("ghp_1234567890"), "ghp_...");
-    }
 }

--- a/tests/integration/one-shot-tokens.test.ts
+++ b/tests/integration/one-shot-tokens.test.ts
@@ -78,8 +78,8 @@ describe('One-Shot Token Protection', () => {
       // Both reads succeed (each printenv is a separate process)
       expect(result.stdout).toContain('First read: [ghp_test_token_12345]');
       expect(result.stdout).toContain('Second read: [ghp_test_token_12345]');
-      // Verify the one-shot-token library logged the token access with value preview
-      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (value: ghp_...)');
+      // Verify the one-shot-token library logged the token access without exposing the value
+      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (length: 20)');
     }, 120000);
 
     test('should cache COPILOT_GITHUB_TOKEN and clear from environment', async () => {
@@ -107,7 +107,7 @@ describe('One-Shot Token Protection', () => {
       expect(result).toSucceed();
       expect(result.stdout).toContain('First read: [copilot_test_token_67890]');
       expect(result.stdout).toContain('Second read: [copilot_test_token_67890]');
-      expect(result.stderr).toContain('[one-shot-token] Token COPILOT_GITHUB_TOKEN accessed and cached (value: copi...)');
+      expect(result.stderr).toContain('[one-shot-token] Token COPILOT_GITHUB_TOKEN accessed and cached (length: 24)');
     }, 120000);
 
     test('should cache OPENAI_API_KEY and clear from environment', async () => {
@@ -135,7 +135,7 @@ describe('One-Shot Token Protection', () => {
       expect(result).toSucceed();
       expect(result.stdout).toContain('First read: [sk-test-openai-key]');
       expect(result.stdout).toContain('Second read: [sk-test-openai-key]');
-      expect(result.stderr).toContain('[one-shot-token] Token OPENAI_API_KEY accessed and cached (value: sk-t...)');
+      expect(result.stderr).toContain('[one-shot-token] Token OPENAI_API_KEY accessed and cached (length: 18)');
     }, 120000);
 
     test('should handle multiple different tokens independently', async () => {
@@ -242,7 +242,7 @@ print(f"Second: [{second}]")
       // Both reads should succeed (second read returns cached value)
       expect(result.stdout).toContain('First: [ghp_python_test_token]');
       expect(result.stdout).toContain('Second: [ghp_python_test_token]');
-      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (value: ghp_...)');
+      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (length: 21)');
     }, 120000);
 
     test('should clear token from /proc/self/environ while caching for getenv()', async () => {
@@ -317,8 +317,8 @@ print(f"Second getenv: [{second}]")
       expect(result.stdout).toContain('Second read: [ghp_chroot_token_12345]');
       // Verify the library was copied to the chroot
       expect(result.stderr).toContain('One-shot token library copied to chroot');
-      // Verify the one-shot-token library logged the token access with value preview
-      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (value: ghp_...)');
+      // Verify the one-shot-token library logged the token access without exposing the value
+      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (length: 22)');
     }, 120000);
 
     test('should cache COPILOT_GITHUB_TOKEN in chroot mode', async () => {
@@ -346,7 +346,7 @@ print(f"Second getenv: [{second}]")
       expect(result).toSucceed();
       expect(result.stdout).toContain('First read: [copilot_chroot_token_67890]');
       expect(result.stdout).toContain('Second read: [copilot_chroot_token_67890]');
-      expect(result.stderr).toContain('[one-shot-token] Token COPILOT_GITHUB_TOKEN accessed and cached (value: copi...)');
+      expect(result.stderr).toContain('[one-shot-token] Token COPILOT_GITHUB_TOKEN accessed and cached (length: 26)');
     }, 120000);
 
     test('should return cached value on subsequent getenv() in chroot mode', async () => {
@@ -375,7 +375,7 @@ print(f"Second: [{second}]")
       expect(result).toSucceed();
       expect(result.stdout).toContain('First: [ghp_chroot_python_token]');
       expect(result.stdout).toContain('Second: [ghp_chroot_python_token]');
-      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (value: ghp_...)');
+      expect(result.stderr).toContain('[one-shot-token] Token GITHUB_TOKEN accessed and cached (length: 23)');
     }, 120000);
 
     test('should not interfere with non-sensitive variables in chroot mode', async () => {


### PR DESCRIPTION
## Summary

- Remove `format_token_value()` from both C and Rust one-shot-token implementations which leaked the first 4 characters of sensitive tokens to stderr
- Replace with token length logging (`length: N`) which provides useful debug info without exposing secret material
- Update integration tests and documentation to match new log format

## Details

The one-shot-token LD_PRELOAD library was logging partial token values like `ghp_...` and `sk-a...` when debug mode was enabled. While this only occurs with `AWF_ONE_SHOT_TOKEN_DEBUG=1`, CI environments capture stderr logs which persist for 90 days, creating an unnecessary exposure of token prefixes that reveal token type information.

Fixes #758

## Test plan

- [x] All 831 unit tests pass
- [x] Lint passes (0 errors)
- [x] Integration test assertions updated to expect `(length: N)` format
- [x] Both C (`one-shot-token.c`) and Rust (`src/lib.rs`) implementations updated
- [x] README examples updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)