### PR TITLE
test: add workDir tmpfs hiding integration tests

### DIFF
--- a/tests/integration/workdir-tmpfs-hiding.test.ts
+++ b/tests/integration/workdir-tmpfs-hiding.test.ts
@@ -8,11 +8,11 @@
  * Security Threat Model:
  * - docker-compose.yml in the workDir contains every env var passed to the container
  * - Without tmpfs overlay, an agent could read secrets via:
- *   cat /tmp/awf-*/docker-compose.yml (normal path)
- *   cat /host/tmp/awf-*/docker-compose.yml (chroot path)
+ *   cat /tmp/awf-{ts}/docker-compose.yml (normal path)
+ *   cat /host/tmp/awf-{ts}/docker-compose.yml (chroot path)
  *
  * Security Mitigation:
- * - tmpfs is mounted over both ${workDir} and /host${workDir}
+ * - tmpfs is mounted over both workDir and /host/workDir
  * - This makes the directory appear empty to the agent
  * - Subdirectory volume mounts (agent-logs, squid-logs) are unaffected
  *


### PR DESCRIPTION
## Summary
- Adds 7 integration tests verifying the tmpfs overlay on workDir prevents agents from reading `docker-compose.yml` (which contains plaintext tokens)
- Tests cover both normal mode and chroot mode (`/host` prefix paths)
- Includes security verification tests (grep for secrets, env var canary)

## Test Coverage
| Test | Description |
|------|-------------|
| Test 1 | docker-compose.yml not readable in workDir |
| Test 2 | workDir appears empty to the agent |
| Test 3 | Env var canary value not leaked via workDir files |
| Test 4 | docker-compose.yml not readable at /host path (chroot) |
| Test 5 | /host workDir also appears empty |
| Test 6 | grep for secrets in workDir finds nothing |
| Test 7 | Debug logs confirm tmpfs overlay configuration |

Fixes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)