### PR TITLE
test: add --allow-host-ports validation tests

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { parseEnvironmentVariables, parseDomains, parseDomainsFile, escapeShellArg, joinShellArgs, parseVolumeMounts, isValidIPv4, isValidIPv6, parseDnsServers, validateAgentImage, isAgentImagePreset, AGENT_IMAGE_PRESETS, processAgentImageOption, processLocalhostKeyword, validateSkipPullWithBuildLocal, validateFormat, validateApiProxyConfig, buildRateLimitConfig, validateRateLimitFlags } from './cli';
+import { parseEnvironmentVariables, parseDomains, parseDomainsFile, escapeShellArg, joinShellArgs, parseVolumeMounts, isValidIPv4, isValidIPv6, parseDnsServers, validateAgentImage, isAgentImagePreset, AGENT_IMAGE_PRESETS, processAgentImageOption, processLocalhostKeyword, validateSkipPullWithBuildLocal, validateAllowHostPorts, validateFormat, validateApiProxyConfig, buildRateLimitConfig, validateRateLimitFlags } from './cli';
 import { redactSecrets } from './redact-secrets';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -1493,6 +1493,50 @@ describe('cli', () => {
     it('should pass when all flags used with api proxy enabled', () => {
       const r = validateRateLimitFlags(true, { rateLimitRpm: '10', rateLimitRph: '100', rateLimit: false });
       expect(r.valid).toBe(true);
+    });
+  });
+
+  describe('validateAllowHostPorts', () => {
+    it('should fail when --allow-host-ports is used without --enable-host-access', () => {
+      const result = validateAllowHostPorts('3000', undefined);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('--allow-host-ports requires --enable-host-access');
+    });
+
+    it('should fail when --allow-host-ports is used with enableHostAccess=false', () => {
+      const result = validateAllowHostPorts('8080', false);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('--allow-host-ports requires --enable-host-access');
+    });
+
+    it('should pass when --allow-host-ports is used with --enable-host-access', () => {
+      const result = validateAllowHostPorts('3000', true);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should pass when --allow-host-ports is not provided', () => {
+      const result = validateAllowHostPorts(undefined, undefined);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should pass when only --enable-host-access is set without ports', () => {
+      const result = validateAllowHostPorts(undefined, true);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should fail for port ranges without --enable-host-access', () => {
+      const result = validateAllowHostPorts('3000-3010,8080', undefined);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('--allow-host-ports requires --enable-host-access');
+    });
+
+    it('should pass for port ranges with --enable-host-access', () => {
+      const result = validateAllowHostPorts('3000-3010,8000-8090', true);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -404,6 +404,25 @@ export function validateSkipPullWithBuildLocal(
 }
 
 /**
+ * Validates that --allow-host-ports is only used with --enable-host-access
+ * @param allowHostPorts - The --allow-host-ports value (undefined if not provided)
+ * @param enableHostAccess - Whether --enable-host-access flag was provided
+ * @returns FlagValidationResult with validation status and error message
+ */
+export function validateAllowHostPorts(
+  allowHostPorts: string | undefined,
+  enableHostAccess: boolean | undefined
+): FlagValidationResult {
+  if (allowHostPorts && !enableHostAccess) {
+    return {
+      valid: false,
+      error: '--allow-host-ports requires --enable-host-access to be set',
+    };
+  }
+  return { valid: true };
+}
+
+/**
  * Parses and validates DNS servers from a comma-separated string
  * @param input - Comma-separated DNS server string (e.g., "8.8.8.8,1.1.1.1")
  * @returns Array of validated DNS server IP addresses
@@ -1110,9 +1129,10 @@ program
       logger.warn('   This may expose sensitive credentials if logs or configs are shared');
     }
 
-    // Warn if --allow-host-ports is used without --enable-host-access
-    if (config.allowHostPorts && !config.enableHostAccess) {
-      logger.error('❌ --allow-host-ports requires --enable-host-access to be set');
+    // Validate --allow-host-ports requires --enable-host-access
+    const hostPortsValidation = validateAllowHostPorts(config.allowHostPorts, config.enableHostAccess);
+    if (!hostPortsValidation.valid) {
+      logger.error(`❌ ${hostPortsValidation.error}`);
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- Extracts `validateAllowHostPorts()` function from inline CLI validation for testability
- Adds 7 unit tests covering all edge cases: error without `--enable-host-access`, pass with `--enable-host-access`, undefined ports, port ranges, and combined flag scenarios

Fixes #498

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (846 tests, 7 new)
- [x] `npm run lint` passes (0 errors)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)