### PR TITLE
test: add --skip-pull integration test

### DIFF
--- a/tests/fixtures/awf-runner.ts
+++ b/tests/fixtures/awf-runner.ts
@@ -25,6 +25,7 @@ export interface AwfOptions {
   noRateLimit?: boolean; // Disable rate limiting
   envAll?: boolean; // Pass all host environment variables to container (--env-all)
   cliEnv?: Record<string, string>; // Explicit -e KEY=VALUE flags passed to AWF CLI
+  skipPull?: boolean; // Use local images without pulling from registry (--skip-pull)
 }
 
 export interface AwfResult {
@@ -74,6 +75,10 @@ export class AwfRunner {
 
     if (options.buildLocal) {
       args.push('--build-local');
+    }
+
+    if (options.skipPull) {
+      args.push('--skip-pull');
     }
 
     if (options.imageRegistry) {
@@ -254,6 +259,10 @@ export class AwfRunner {
 
     if (options.buildLocal) {
       args.push('--build-local');
+    }
+
+    if (options.skipPull) {
+      args.push('--skip-pull');
     }
 
     if (options.imageRegistry) {

--- a/tests/integration/skip-pull.test.ts
+++ b/tests/integration/skip-pull.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Skip Pull Flag Tests
+ *
+ * These tests verify the --skip-pull flag behavior:
+ * - Success when images are pre-downloaded (uses --build-local first to ensure images exist)
+ * - Error when images are not available locally
+ * - Rejection of --skip-pull with --build-local (incompatible flags)
+ */
+
+/// <reference path="../jest-custom-matchers.d.ts" />
+
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { createRunner, AwfRunner } from '../fixtures/awf-runner';
+import { cleanup } from '../fixtures/cleanup';
+
+describe('Skip Pull Flag', () => {
+  let runner: AwfRunner;
+
+  beforeAll(async () => {
+    await cleanup(false);
+    runner = createRunner();
+  });
+
+  afterAll(async () => {
+    await cleanup(false);
+  });
+
+  test('should succeed with --skip-pull when images are pre-downloaded', async () => {
+    // First, ensure images exist locally by building them
+    const buildResult = await runner.runWithSudo(
+      'echo "images built"',
+      {
+        allowDomains: ['github.com'],
+        buildLocal: true,
+        logLevel: 'debug',
+        timeout: 120000,
+      }
+    );
+    expect(buildResult).toSucceed();
+
+    // Now run with --skip-pull, which should use the locally available images
+    const result = await runner.runWithSudo(
+      'echo "skip-pull works"',
+      {
+        allowDomains: ['github.com'],
+        skipPull: true,
+        logLevel: 'debug',
+        timeout: 60000,
+      }
+    );
+
+    expect(result).toSucceed();
+    expect(result.stdout).toContain('skip-pull works');
+  }, 240000);
+
+  test('should fail with --skip-pull when images are not available locally', async () => {
+    // Use a non-existent image tag so Docker cannot find it locally
+    const result = await runner.runWithSudo(
+      'echo "should not reach here"',
+      {
+        allowDomains: ['github.com'],
+        skipPull: true,
+        imageTag: 'nonexistent-tag-xyz-999',
+        logLevel: 'debug',
+        timeout: 60000,
+      }
+    );
+
+    expect(result).toFail();
+  }, 120000);
+
+  test('should reject --skip-pull with --build-local', async () => {
+    const result = await runner.runWithSudo(
+      'echo "should not reach here"',
+      {
+        allowDomains: ['github.com'],
+        skipPull: true,
+        buildLocal: true,
+        logLevel: 'debug',
+        timeout: 30000,
+      }
+    );
+
+    expect(result).toFail();
+    expect(result.stderr).toContain('--skip-pull cannot be used with --build-local');
+  }, 60000);
+});


### PR DESCRIPTION
## Summary
- Adds `skipPull` option to `AwfRunner` test fixture
- Creates `tests/integration/skip-pull.test.ts` with 3 integration tests:
  - Success when images are pre-downloaded
  - Error when images not available locally
  - Rejection of `--skip-pull` with `--build-local`

Fixes #497

## Test plan
- [x] Unit tests pass (839)
- [x] Lint passes
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)