### PR TITLE
docs: sync version references and add missing CLI flags

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -428,6 +428,35 @@ SSL Bump requires intercepting HTTPS traffic:
 
 For more details, see [SSL Bump documentation](ssl-bump.md).
 
+## API Proxy Sidecar
+
+The `--enable-api-proxy` flag deploys a Node.js proxy sidecar that securely holds LLM API credentials and automatically injects authentication headers. This keeps API keys isolated from the agent container.
+
+```bash
+# Enable the API proxy sidecar (reads keys from environment)
+sudo awf \
+  --allow-domains api.openai.com,api.anthropic.com \
+  --enable-api-proxy \
+  -- your-agent-command
+```
+
+When enabled, the proxy:
+- Isolates API keys from the agent container (keys never enter the agent environment)
+- Automatically injects Bearer tokens for OpenAI and Anthropic APIs
+- Routes all traffic through Squid to respect domain whitelisting
+
+Rate limiting is available with the API proxy:
+```bash
+sudo awf \
+  --allow-domains api.openai.com \
+  --enable-api-proxy \
+  --rate-limit-rpm 60 \
+  --rate-limit-rph 1000 \
+  -- your-agent-command
+```
+
+For detailed architecture, credential flow, and configuration, see [API Proxy Sidecar](api-proxy-sidecar.md).
+
 ## Agent Image
 
 The `--agent-image` flag controls which agent container image to use. It supports two presets for quick startup, or custom base images for advanced use cases.
@@ -605,12 +634,16 @@ sudo awf --skip-pull --allow-domains github.com -- your-command
 **Using Specific Versions:**
 ```bash
 # Pre-download specific version
-docker pull ghcr.io/github/gh-aw-firewall/squid:v0.13.0
-docker pull ghcr.io/github/gh-aw-firewall/agent:v0.13.0
+docker pull ghcr.io/github/gh-aw-firewall/squid:latest
+docker pull ghcr.io/github/gh-aw-firewall/agent:latest
 
-# Tag as latest for awf to use
-docker tag ghcr.io/github/gh-aw-firewall/squid:v0.13.0 ghcr.io/github/gh-aw-firewall/squid:latest
-docker tag ghcr.io/github/gh-aw-firewall/agent:v0.13.0 ghcr.io/github/gh-aw-firewall/agent:latest
+# Or pin to a specific version
+docker pull ghcr.io/github/gh-aw-firewall/squid:v0.16.2
+docker pull ghcr.io/github/gh-aw-firewall/agent:v0.16.2
+
+# Tag a specific version as latest for awf to use
+docker tag ghcr.io/github/gh-aw-firewall/squid:v0.16.2 ghcr.io/github/gh-aw-firewall/squid:latest
+docker tag ghcr.io/github/gh-aw-firewall/agent:v0.16.2 ghcr.io/github/gh-aw-firewall/agent:latest
 
 # Use with --skip-pull
 sudo awf --skip-pull --allow-domains github.com -- your-command


### PR DESCRIPTION
## Summary
- Updated Docker image examples from `v0.13.0` to `latest` tag in `docs/usage.md`
- Added dedicated `--enable-api-proxy` section in `docs/usage.md` with usage examples, rate limiting examples, and a link to `api-proxy-sidecar.md`

**Notes on issue scope:**
- `docs/quickstart.md` version was already at `0.18.0` (newer than the `0.16.2` target in #836), so no change was needed
- `--allow-full-filesystem-access` flag referenced in #836 does not exist in the codebase (`src/cli.ts`), so it was not documented. This may need a separate issue to either add the flag or remove it from the tracking issue.

Closes #836

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Changes are docs-only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)