### PR TITLE
docs: clarify --image-tag behavior with agent-image presets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,6 +35,9 @@ Options:
                                  ghcr.io/catthehacker/ubuntu:full-XX.XX
   --image-registry <registry>  Container image registry (default: ghcr.io/github/gh-aw-firewall)
   --image-tag <tag>            Container image tag (default: latest)
+                               Image name varies by --agent-image preset:
+                                 default → agent:<tag>
+                                 act     → agent-act:<tag>
   --skip-pull                  Use local images without pulling from registry (requires images to be
                                pre-downloaded) (default: false)
   -e, --env <KEY=VALUE>        Additional environment variables to pass to container (can be

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -729,7 +729,10 @@ program
   )
   .option(
     '--image-tag <tag>',
-    'Container image tag',
+    'Container image tag (applies to both squid and agent images)\n' +
+    '                                   Image name varies by --agent-image preset:\n' +
+    '                                     default → agent:<tag>\n' +
+    '                                     act     → agent-act:<tag>',
     'latest'
   )
   .option(


### PR DESCRIPTION
## Summary
- Updated `--image-tag` help text in CLI to explain that the image name varies by `--agent-image` preset (`default` → `agent:<tag>`, `act` → `agent-act:<tag>`)
- Updated `docs/usage.md` with the same clarification

Fixes #502

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (839 tests)
- [x] `npm run lint` passes (warnings only, no errors)
- [ ] Verify `awf --help` shows updated `--image-tag` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)