### PR TITLE
feat(cli): add short flags for frequently used options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 sudo awf [options] -- <command>
 
 Options:
-  --allow-domains <domains>  Comma-separated list of allowed domains. Supports wildcards and protocol prefixes:
+  -d, --allow-domains <domains>  Comma-separated list of allowed domains. Supports wildcards and protocol prefixes:
                              - github.com: exact domain + subdomains (HTTP & HTTPS)
                              - *.github.com: any subdomain of github.com
                              - api-*.example.com: prefix wildcards
@@ -20,11 +20,11 @@ Options:
   --block-domains-file <path>  Path to file containing blocked domains (one per line or
                                comma-separated, supports # comments)
   --log-level <level>          Log level: debug, info, warn, error (default: info)
-  --keep-containers            Keep containers running after command exits (default: false)
+  -k, --keep-containers        Keep containers running after command exits (default: false)
   --tty                        Allocate a pseudo-TTY for the container (required for interactive
                                tools like Claude Code) (default: false)
   --work-dir <dir>             Working directory for temporary files
-  --build-local                Build containers locally instead of using GHCR images (default: false)
+  -b, --build-local            Build containers locally instead of using GHCR images (default: false)
   --agent-image <value>        Agent container image (default: "default")
                                Presets (pre-built, fast):
                                  default  - Minimal ubuntu:22.04 (~200MB)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -665,7 +665,7 @@ program
   .description('Network firewall for agentic workflows with domain whitelisting')
   .version(version)
   .option(
-    '--allow-domains <domains>',
+    '-d, --allow-domains <domains>',
     'Comma-separated list of allowed domains. Supports wildcards and protocol prefixes:\n' +
     '                                   github.com         - exact domain + subdomains (HTTP & HTTPS)\n' +
     '                                   *.github.com       - any subdomain of github.com\n' +
@@ -692,7 +692,7 @@ program
     'info'
   )
   .option(
-    '--keep-containers',
+    '-k, --keep-containers',
     'Keep containers running after command exits',
     false
   )
@@ -707,7 +707,7 @@ program
     path.join(os.tmpdir(), `awf-${Date.now()}`)
   )
   .option(
-    '--build-local',
+    '-b, --build-local',
     'Build containers locally instead of using GHCR images',
     false
   )


### PR DESCRIPTION
## Summary
- Add `-d` as short flag for `--allow-domains`
- Add `-b` as short flag for `--build-local`
- Add `-k` as short flag for `--keep-containers`

These are the three most frequently used options and having short flags improves CLI ergonomics.

Fixes #501

## Test plan
- [x] All 839 existing tests pass
- [x] Build succeeds
- [x] Lint passes (0 errors)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)