### PR TITLE
fix(cli): clear LD_PRELOAD after one-shot-token library loads

### DIFF
--- a/containers/agent/one-shot-token/src/lib.rs
+++ b/containers/agent/one-shot-token/src/lib.rs
@@ -198,6 +198,7 @@ fn init_token_list(state: &mut TokenState) {
                         );
                     }
                     state.initialized = true;
+                    clear_ld_preload(state.debug_enabled);
                     return;
                 }
 
@@ -225,6 +226,26 @@ fn init_token_list(state: &mut TokenState) {
         );
     }
     state.initialized = true;
+    clear_ld_preload(state.debug_enabled);
+}
+
+/// Unset LD_PRELOAD and LD_LIBRARY_PATH from the environment so child processes
+/// don't inherit them. The library is already loaded in this process's address space,
+/// so getenv interception continues to work. This fixes Deno 2.x's scoped --allow-run
+/// permissions which reject spawning subprocesses when LD_PRELOAD is set.
+/// See: https://github.com/github/gh-aw-firewall/issues/1001
+fn clear_ld_preload(debug_enabled: bool) {
+    // SAFETY: unsetenv is a standard POSIX function. We pass valid C strings.
+    unsafe {
+        let ld_preload = CString::new("LD_PRELOAD").unwrap();
+        libc::unsetenv(ld_preload.as_ptr());
+        let ld_library_path = CString::new("LD_LIBRARY_PATH").unwrap();
+        libc::unsetenv(ld_library_path.as_ptr());
+    }
+
+    if debug_enabled {
+        eprintln!("[one-shot-token] Cleared LD_PRELOAD and LD_LIBRARY_PATH from environment");
+    }
 }
 
 /// Check if a token name is sensitive
@@ -431,6 +452,32 @@ mod tests {
         assert!(state.tokens.is_empty());
         assert!(state.cache.is_empty());
         assert!(!state.initialized);
+    }
+
+    #[test]
+    fn test_clear_ld_preload_removes_env_vars() {
+        // Set LD_PRELOAD and LD_LIBRARY_PATH in the environment
+        unsafe {
+            let key = CString::new("LD_PRELOAD").unwrap();
+            let val = CString::new("/tmp/test.so").unwrap();
+            libc::setenv(key.as_ptr(), val.as_ptr(), 1);
+
+            let key2 = CString::new("LD_LIBRARY_PATH").unwrap();
+            let val2 = CString::new("/tmp/lib").unwrap();
+            libc::setenv(key2.as_ptr(), val2.as_ptr(), 1);
+        }
+
+        // Call clear_ld_preload
+        clear_ld_preload(false);
+
+        // Verify they were unset
+        unsafe {
+            let key = CString::new("LD_PRELOAD").unwrap();
+            assert!(call_real_getenv(key.as_ptr()).is_null());
+
+            let key2 = CString::new("LD_LIBRARY_PATH").unwrap();
+            assert!(call_real_getenv(key2.as_ptr()).is_null());
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- Modifies the one-shot-token Rust LD_PRELOAD library to unset `LD_PRELOAD` and `LD_LIBRARY_PATH` from the process environment after initialization
- The library remains loaded in the current process's address space, so `getenv` interception continues to work for token protection
- Child processes no longer inherit these environment variables, fixing Deno 2.x's scoped `--allow-run` permission model

## Problem

AWF's `LD_PRELOAD=/usr/local/lib/one-shot-token.so` conflicts with Deno 2.x's scoped permission model. When Deno tests use `--allow-run=deno`, Deno refuses to spawn subprocesses because they would inherit `LD_PRELOAD` and `LD_LIBRARY_PATH`, which Deno considers a security risk.

Error: `NotCapable: Requires --allow-run permissions to spawn subprocess with LD_LIBRARY_PATH, LD_PRELOAD environment variables`

## Solution

After `init_token_list()` completes (the library is loaded and ready to intercept `getenv` calls), call `unsetenv("LD_PRELOAD")` and `unsetenv("LD_LIBRARY_PATH")`. Since the shared library is already mapped into the process's address space, the `getenv` interception continues to work. Child processes simply don't load the library, which is fine because tokens are already unset from the environment by the parent.

## Test plan

- [x] Rust unit tests pass (3 tests including new `test_clear_ld_preload_removes_env_vars`)
- [x] TypeScript build passes
- [x] All 839 unit tests pass
- [x] Lint passes (0 errors)
- [ ] CI integration tests pass

Fixes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)