### PR TITLE
ci: skip CI when only release.yml changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '.github/workflows/release.yml'
   schedule:
     # Run at 00:00 UTC every Monday
     - cron: '0 0 * * 1'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
+      - '.github/workflows/release.yml'
   schedule:
     # Run weekly on Mondays at 00:00 UTC
     - cron: '0 0 * * 1'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
+      - '.github/workflows/release.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-chroot.yml
+++ b/.github/workflows/test-chroot.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
+      - '.github/workflows/release.yml'
   push:
     branches: [main]
 

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-integration-suite.yml
+++ b/.github/workflows/test-integration-suite.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Adds `paths-ignore: ['.github/workflows/release.yml']` to 10 CI workflow triggers so that PRs modifying only `release.yml` don't trigger slow integration tests and other unnecessary checks
- Affected workflows: build, codeql, dependency-audit, lint, test-action, test-chroot, test-coverage, test-examples, test-integration-suite, test-integration
- `workflow_dispatch` and `push` to `main` triggers are unchanged, so scheduled/manual runs still work

## Test plan
- [ ] Verify this PR itself triggers the expected subset of workflows (all workflows should still run since this PR touches workflow files beyond just release.yml)
- [ ] Create a test PR that only modifies `release.yml` and confirm no test/build workflows are triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)