### PR TITLE
fix: eliminate 10s container shutdown delay

### DIFF
--- a/containers/api-proxy/Dockerfile
+++ b/containers/api-proxy/Dockerfile
@@ -30,6 +30,5 @@ USER apiproxy
 # 10004 - OpenCode API proxy (routes to Anthropic)
 EXPOSE 10000 10001 10002 10004
 
-# Redirect stdout/stderr to log file for persistence
-# Use shell form to enable redirection and tee for both file and console
-CMD node server.js 2>&1 | tee -a /var/log/api-proxy/api-proxy.log
+# Use exec form so node is PID 1 and receives SIGTERM directly
+CMD ["node", "server.js"]

--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -538,6 +538,12 @@ describe('docker-manager', () => {
       expect(squid.ports).toContain('3128:3128');
     });
 
+    it('should set stop_grace_period on squid service', () => {
+      const result = generateDockerCompose(mockConfig, mockNetworkConfig);
+      const squid = result.services['squid-proxy'] as any;
+      expect(squid.stop_grace_period).toBe('2s');
+    });
+
     it('should inject squid config via base64 env var when content is provided', () => {
       const squidConfig = 'http_port 3128\nacl allowed_domains dstdomain .github.com\n';
       const result = generateDockerCompose(mockConfig, mockNetworkConfig, undefined, squidConfig);
@@ -1787,6 +1793,13 @@ describe('docker-manager', () => {
         const proxy = result.services['api-proxy'];
         expect(proxy.cap_drop).toEqual(['ALL']);
         expect(proxy.security_opt).toContain('no-new-privileges:true');
+      });
+
+      it('should set stop_grace_period on api-proxy service', () => {
+        const configWithProxy = { ...mockConfig, enableApiProxy: true, openaiApiKey: 'sk-test-key' };
+        const result = generateDockerCompose(configWithProxy, mockNetworkConfigWithProxy);
+        const proxy = result.services['api-proxy'] as any;
+        expect(proxy.stop_grace_period).toBe('2s');
       });
 
       it('should set resource limits', () => {

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -325,6 +325,7 @@ export function generateDockerCompose(
       'AUDIT_WRITE',  // No audit log writing
       'SETFCAP',      // No setting file capabilities
     ],
+    stop_grace_period: '2s',
   };
 
   // Inject squid.conf via environment variable instead of bind mount.
@@ -1238,6 +1239,7 @@ export function generateDockerCompose(
       memswap_limit: '512m',
       pids_limit: 100,
       cpu_shares: 512,
+      stop_grace_period: '2s',
     };
 
     // Use GHCR image or build locally

--- a/src/squid-config.test.ts
+++ b/src/squid-config.test.ts
@@ -568,6 +568,15 @@ describe('generateSquidConfig', () => {
       const result = generateSquidConfig(config);
       expect(result).toContain('pconn_timeout 2 minutes');
     });
+
+    it('should include shutdown_lifetime 0 for fast shutdown', () => {
+      const config: SquidConfig = {
+        domains: ['example.com'],
+        port: defaultPort,
+      };
+      const result = generateSquidConfig(config);
+      expect(result).toContain('shutdown_lifetime 0 seconds');
+    });
   });
 
   describe('Real-world Domain Patterns', () => {

--- a/src/squid-config.ts
+++ b/src/squid-config.ts
@@ -606,6 +606,10 @@ client_lifetime 8 hours
 # Critical for SSE where server sends but client doesn't respond
 half_closed_clients on
 
+# shutdown_lifetime: Time to wait for active connections during shutdown
+# Set to 0 because this is an ephemeral proxy — no connection draining needed
+shutdown_lifetime 0 seconds
+
 # Debugging (can be enabled for troubleshooting)
 # debug_options ALL,1 33,2
 `;


### PR DESCRIPTION
## Summary

Fixes #1371

Three root causes contributed to a ~10-second delay during `docker compose down`:

- **api-proxy shell-form CMD**: The Dockerfile used `CMD node server.js 2>&1 | tee ...` (shell form), so `node` ran under `/bin/sh` as a child process. `/bin/sh` does not forward SIGTERM to children, causing Docker to wait the full stop timeout before sending SIGKILL. Switched to exec form `CMD ["node", "server.js"]` so node is PID 1 and receives SIGTERM directly.

- **Squid shutdown_lifetime**: Squid's default `shutdown_lifetime` (30s) causes it to wait for active connections to drain on SIGTERM. Added `shutdown_lifetime 0 seconds` since this is an ephemeral per-session proxy with no need for connection draining.

- **Docker Compose stop timeout**: Docker Compose defaults to a 10-second stop timeout before sending SIGKILL. Added `stop_grace_period: 2s` to squid and api-proxy services, which is sufficient now that both containers shut down promptly on SIGTERM.

## Test plan

- [x] `npm run build` compiles successfully
- [x] `npm test` — all 1119 tests pass, including new tests for `shutdown_lifetime` and `stop_grace_period`
- [x] `npm run lint` — no errors (only pre-existing warnings)
- [ ] Integration: verify `docker compose down` completes in ~2s instead of ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)