### PR TITLE
chore(deps): update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -35,14 +35,14 @@ jobs:
           docker build -t awf-agent:${{ github.sha }} ./containers/agent
 
       - name: Run Trivy vulnerability scanner (table output)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'awf-agent:${{ github.sha }}'
           format: 'table'
           severity: 'CRITICAL,HIGH'
 
       - name: Run Trivy vulnerability scanner (SARIF output)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'awf-agent:${{ github.sha }}'
           format: 'sarif'
@@ -70,14 +70,14 @@ jobs:
           docker build -t awf-squid:${{ github.sha }} ./containers/squid
 
       - name: Run Trivy vulnerability scanner (table output)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'awf-squid:${{ github.sha }}'
           format: 'table'
           severity: 'CRITICAL,HIGH'
 
       - name: Run Trivy vulnerability scanner (SARIF output)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'awf-squid:${{ github.sha }}'
           format: 'sarif'


### PR DESCRIPTION
Updates `aquasecurity/trivy-action` from v0.33.1 to v0.35.0 in the container-scan workflow.

All 4 references updated (agent table, agent SARIF, squid table, squid SARIF) with pinned commit SHA.