### PR TITLE
fix: copy AWF CA cert to chroot-accessible path for ssl-bump

### DIFF
--- a/containers/agent/entrypoint.sh
+++ b/containers/agent/entrypoint.sh
@@ -486,7 +486,8 @@ if [ "${AWF_CHROOT_ENABLED}" = "true" ]; then
   AWF_CA_CHROOT=""
   if [ "${AWF_SSL_BUMP_ENABLED}" = "true" ] && [ -f /usr/local/share/ca-certificates/awf-ca.crt ]; then
     if mkdir -p /host/tmp/awf-lib 2>/dev/null; then
-      if cp /usr/local/share/ca-certificates/awf-ca.crt /host/tmp/awf-lib/awf-ca.crt 2>/dev/null; then
+      if cp /usr/local/share/ca-certificates/awf-ca.crt /host/tmp/awf-lib/awf-ca.crt 2>/dev/null && \
+         [ -f /host/tmp/awf-lib/awf-ca.crt ]; then
         AWF_CA_CHROOT="/tmp/awf-lib/awf-ca.crt"
         export NODE_EXTRA_CA_CERTS="$AWF_CA_CHROOT"
         # SSL_CERT_FILE is respected by curl, git, Python requests, Ruby, and most
@@ -499,6 +500,8 @@ if [ "${AWF_CHROOT_ENABLED}" = "true" ]; then
       else
         echo "[entrypoint][WARN] Could not copy AWF CA certificate to chroot — ssl-bump TLS may fail"
       fi
+    else
+      echo "[entrypoint][WARN] Could not create /host/tmp/awf-lib for CA cert — ssl-bump TLS may fail in chroot"
     fi
   fi
 


### PR DESCRIPTION
## Problem

When `--ssl-bump` and `--chroot` are both active, `NODE_EXTRA_CA_CERTS` points to `/usr/local/share/ca-certificates/awf-ca.crt` — a Docker volume mount on the container's overlay filesystem. After `chroot /host`, this path is inaccessible because it's not under the `/host` mount tree.

**Symptom:** Claude Code exhausts 10 API retries with `EHOSTUNREACH`. Squid logs show `transaction-end-before-headers` with `NONE_NONE` decisions because the dynamically-generated ssl-bump certificate (signed by the AWF CA) is rejected by Node.js.

## Root Cause

The CA cert is mounted into the container at `/usr/local/share/ca-certificates/awf-ca.crt` by `docker-manager.ts`. The `entrypoint.sh` sets `NODE_EXTRA_CA_CERTS` to this path. But after `chroot /host`, the filesystem root changes to the host mount, and the container-side path no longer exists.

## Solution

Apply the same copy pattern used for `one-shot-token.so` and `get-claude-key.sh`: copy the CA cert to `/host/tmp/awf-lib/` before the chroot activates, then update env vars to the chroot-relative path `/tmp/awf-lib/awf-ca.crt`.

### Changes in `containers/agent/entrypoint.sh`:

1. **Non-chroot ssl-bump** (lines 104-119): Also set `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` so non-Node.js tools (curl, git, Python) trust the AWF CA

2. **Chroot ssl-bump** (new block after get-claude-key.sh copy): Copy CA cert to `/host/tmp/awf-lib/awf-ca.crt` and update `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, and `REQUESTS_CA_BUNDLE` to the chroot-relative path

3. **Cleanup** (line 726): Extended cleanup condition to also trigger when `AWF_CA_CHROOT` is set (ensures `/tmp/awf-lib` is cleaned up even if one-shot-token was not copied)

### Env vars set for ssl-bump:
| Variable | Purpose | Tools |
|----------|---------|-------|
| `NODE_EXTRA_CA_CERTS` | Node.js CA bundle | Claude Code, npm, Yarn, Corepack |
| `SSL_CERT_FILE` | OpenSSL CA file | curl, git, Ruby |
| `REQUESTS_CA_BUNDLE` | Python requests CA | Python requests, pip |

## Verification

The fix can be verified by running with `--ssl-bump --chroot` and confirming:
- `NODE_EXTRA_CA_CERTS` resolves to an accessible path after chroot
- `curl https://allowed-domain` succeeds without certificate errors
- Claude Code connects without `EHOSTUNREACH`

Fixes #1546
Upstream: https://github.com/github/gh-aw/issues/23765