### PR TITLE
fix: rename and scope token analyzer to Copilot workflows

### DIFF
--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -20,19 +20,19 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Daily token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities
+# Daily Copilot token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities
 #
 # Resolved workflow manifest:
 #   Imports:
 #     - shared/mcp-pagination.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"55567a725745e7fb379878da0d64b947e29b38d6de9bbe105473317808dd32c1","compiler_version":"v0.65.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"df031d3435512cb54e4939154d5049821affc4bf96e14869ef9257f9e63d0056","compiler_version":"v0.65.3","strict":true,"agent_id":"copilot"}
 
-name: "Daily Token Usage Analyzer"
+name: "Daily Copilot Token Usage Analyzer"
 "on":
   schedule:
-  - cron: "11 19 * * *"
+  - cron: "9 10 * * *"
     # Friendly format: daily (scattered)
   # skip-if-match: # Skip-if-match processed as search check in pre-activation job
     # max: 1
@@ -50,7 +50,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Daily Token Usage Analyzer"
+run-name: "Daily Copilot Token Usage Analyzer"
 
 jobs:
   activation:
@@ -79,7 +79,7 @@ jobs:
           GH_AW_INFO_VERSION: "latest"
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.65.3"
-          GH_AW_INFO_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_INFO_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -113,7 +113,7 @@ jobs:
       - name: Check workflow file timestamps
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "token-usage-analyzer.lock.yml"
+          GH_AW_WORKFLOW_FILE: "copilot-token-usage-analyzer.lock.yml"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -146,14 +146,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a2fade0dc9c4115e_EOF'
+          cat << 'GH_AW_PROMPT_bfc64c312f7792f5_EOF'
           <system>
-          GH_AW_PROMPT_a2fade0dc9c4115e_EOF
+          GH_AW_PROMPT_bfc64c312f7792f5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a2fade0dc9c4115e_EOF'
+          cat << 'GH_AW_PROMPT_bfc64c312f7792f5_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -185,14 +185,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a2fade0dc9c4115e_EOF
+          GH_AW_PROMPT_bfc64c312f7792f5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a2fade0dc9c4115e_EOF'
+          cat << 'GH_AW_PROMPT_bfc64c312f7792f5_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/mcp-pagination.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          {{#runtime-import .github/workflows/token-usage-analyzer.md}}
-          GH_AW_PROMPT_a2fade0dc9c4115e_EOF
+          {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
+          GH_AW_PROMPT_bfc64c312f7792f5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -275,7 +275,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: tokenusageanalyzer
+      GH_AW_WORKFLOW_ID_SANITIZED: copilottokenusageanalyzer
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       has_patch: ${{ steps.collect_output.outputs.has_patch }}
@@ -351,21 +351,21 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a30f3286061706d2_EOF'
-          {"create_issue":{"labels":["token-usage-report"],"max":1,"title_prefix":"📊 Token Usage Report"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a30f3286061706d2_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8108fe0109dae215_EOF'
+          {"create_issue":{"labels":["token-usage-report"],"max":1,"title_prefix":"📊 Copilot Token Usage Report"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_8108fe0109dae215_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_6c00d13077cbe818_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d2050f848fe3a0af_EOF'
           {
             "description_suffixes": {
-              "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Token Usage Report\". Labels [\"token-usage-report\"] will be automatically added."
+              "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report\". Labels [\"token-usage-report\"] will be automatically added."
             },
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_6c00d13077cbe818_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_6b4d31a152ab503d_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_d2050f848fe3a0af_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_df2d27c8daefde8d_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -458,7 +458,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_6b4d31a152ab503d_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_df2d27c8daefde8d_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -526,7 +526,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.10'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_6b4a55541004649a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_64a939eca6fe9586_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -567,7 +567,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6b4a55541004649a_EOF
+          GH_AW_MCP_CONFIG_64a939eca6fe9586_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -773,7 +773,7 @@ jobs:
       contents: read
       issues: write
     concurrency:
-      group: "gh-aw-conclusion-token-usage-analyzer"
+      group: "gh-aw-conclusion-copilot-token-usage-analyzer"
       cancel-in-progress: false
     outputs:
       noop_message: ${{ steps.noop.outputs.noop_message }}
@@ -804,7 +804,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -818,7 +818,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -832,10 +832,10 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "token-usage-analyzer"
+          GH_AW_WORKFLOW_ID: "copilot-token-usage-analyzer"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
@@ -856,7 +856,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -937,8 +937,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Daily Token Usage Analyzer"
-          WORKFLOW_DESCRIPTION: "Daily token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities"
+          WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
+          WORKFLOW_DESCRIPTION: "Daily Copilot token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1032,7 +1032,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_SKIP_QUERY: "is:issue is:open label:token-usage-report"
-          GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+          GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
           GH_AW_SKIP_MAX_MATCHES: "1"
         with:
           script: |
@@ -1052,11 +1052,11 @@ jobs:
       issues: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/token-usage-analyzer"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/copilot-token-usage-analyzer"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_WORKFLOW_ID: "token-usage-analyzer"
-      GH_AW_WORKFLOW_NAME: "Daily Token Usage Analyzer"
+      GH_AW_WORKFLOW_ID: "copilot-token-usage-analyzer"
+      GH_AW_WORKFLOW_NAME: "Daily Copilot Token Usage Analyzer"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1102,7 +1102,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"token-usage-report\"],\"max\":1,\"title_prefix\":\"📊 Token Usage Report\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"token-usage-report\"],\"max\":1,\"title_prefix\":\"📊 Copilot Token Usage Report\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-token-usage-analyzer.md
+++ b/.github/workflows/copilot-token-usage-analyzer.md
@@ -1,5 +1,5 @@
 ---
-description: Daily token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities
+description: Daily Copilot token usage analysis across agentic workflow runs — identifies trends, inefficiencies, and optimization opportunities
 on:
   schedule: daily
   workflow_dispatch:
@@ -24,14 +24,14 @@ tools:
   bash: true
 safe-outputs:
   create-issue:
-    title-prefix: "📊 Token Usage Report"
+    title-prefix: "📊 Copilot Token Usage Report"
     labels: [token-usage-report]
 timeout-minutes: 15
 ---
 
-# Daily Token Usage Analyzer
+# Daily Copilot Token Usage Analyzer
 
-You are an AI agent that analyzes token usage across agentic workflow runs in this repository. Your goal is to identify trends, highlight inefficiencies, and recommend optimizations to reduce AI inference costs.
+You are an AI agent that analyzes Copilot token usage across agentic workflow runs in this repository. Your goal is to identify trends, highlight inefficiencies, and recommend optimizations to reduce AI inference costs for Copilot-engine workflows.
 
 ## Background
 
@@ -156,7 +156,7 @@ If previous reports exist, compare current metrics to identify:
 
 Create an issue with the following structure:
 
-#### Title: `YYYY-MM-DD` (safe-outputs will automatically prefix this with "📊 Token Usage Report")
+#### Title: `YYYY-MM-DD` (safe-outputs will automatically prefix this with "📊 Copilot Token Usage Report")
 
 #### Body structure:
 


### PR DESCRIPTION
## Problem

The token-usage-analyzer workflow timed out at 15 minutes ([run 23875151303](https://github.com/github/gh-aw-firewall/actions/runs/23875151303)) due to two issues:

1. **Artifact downloads blocked** — `gh run download` calls `curl` against `productionresultssa3.blob.core.windows.net`, which wasn't in allowed domains
2. **Too broad scope** — The agent tried to analyze all workflow engines (Copilot, Claude, Codex)

## Changes

- **Rename** `token-usage-analyzer` → `copilot-token-usage-analyzer` to reflect Copilot-only scope
- **Add `*.blob.core.windows.net`** to `network.allowed` so `gh run download` works via bash
- **Scope to Copilot-engine workflows only** (smoke-copilot, build-test, ci-doctor, plan, etc.)
- **Update title-prefix** to `📊 Copilot Token Usage Report`
- **Add time budget + prefer-bash guidance** to keep within 15-minute limit
- **Recompile lock file**