### PR TITLE
fix: enable color output when --tty flag is set

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -610,12 +610,26 @@ describe('docker-manager', () => {
       expect(env.AWF_SSL_BUMP_ENABLED).toBeUndefined();
     });
 
-    it('should set NO_COLOR=1 to disable ANSI color output from CLI tools', () => {
+    it('should set NO_COLOR=1 when tty is false (default)', () => {
       const result = generateDockerCompose(mockConfig, mockNetworkConfig);
       const agent = result.services.agent;
       const env = agent.environment as Record<string, string>;
 
       expect(env.NO_COLOR).toBe('1');
+      expect(env.FORCE_COLOR).toBeUndefined();
+      expect(env.COLUMNS).toBeUndefined();
+    });
+
+    it('should set FORCE_COLOR, TERM, and COLUMNS when tty is true', () => {
+      const ttyConfig = { ...mockConfig, tty: true };
+      const result = generateDockerCompose(ttyConfig, mockNetworkConfig);
+      const agent = result.services.agent;
+      const env = agent.environment as Record<string, string>;
+
+      expect(env.FORCE_COLOR).toBe('1');
+      expect(env.TERM).toBe('xterm-256color');
+      expect(env.COLUMNS).toBe('120');
+      expect(env.NO_COLOR).toBeUndefined();
     });
 
     it('should mount required volumes in agent container (default behavior)', () => {

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -536,10 +536,17 @@ export function generateDockerCompose(
     SQUID_PROXY_PORT: SQUID_PORT.toString(),
     HOME: homeDir,
     PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    // Disable ANSI color output from CLI tools (Rich, Chalk, etc.) inside the container.
-    // Tools like Rich inject ANSI escape codes that break test assertions expecting plain text.
+    // Color output control: when --tty is set, enable color output for tools that support it.
+    // When tty is off (default), disable colors to avoid ANSI escape codes in log output.
     // NO_COLOR is a standard convention (https://no-color.org/) supported by many libraries.
-    NO_COLOR: '1',
+    // FORCE_COLOR is used by Chalk, Rich, and other tools to enable color output.
+    ...(config.tty ? {
+      FORCE_COLOR: '1',
+      TERM: 'xterm-256color',
+      COLUMNS: '120',
+    } : {
+      NO_COLOR: '1',
+    }),
     // Configure one-shot-token library with sensitive tokens to protect
     // These tokens are cached on first access and unset from /proc/self/environ
     AWF_ONE_SHOT_TOKENS: 'COPILOT_GITHUB_TOKEN,GITHUB_TOKEN,GH_TOKEN,GITHUB_API_TOKEN,GITHUB_PAT,GH_ACCESS_TOKEN,OPENAI_API_KEY,OPENAI_KEY,ANTHROPIC_API_KEY,CLAUDE_API_KEY,CODEX_API_KEY',
@@ -649,7 +656,8 @@ export function generateDockerCompose(
     // it gets a placeholder value set earlier (line ~362) for credential isolation
     if (process.env.COPILOT_GITHUB_TOKEN && !config.enableApiProxy) environment.COPILOT_GITHUB_TOKEN = process.env.COPILOT_GITHUB_TOKEN;
     if (process.env.USER) environment.USER = process.env.USER;
-    if (process.env.TERM) environment.TERM = process.env.TERM;
+    // When --tty is set, we use TERM=xterm-256color (set above); otherwise inherit host TERM
+    if (process.env.TERM && !config.tty) environment.TERM = process.env.TERM;
     if (process.env.XDG_CONFIG_HOME) environment.XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
     // Enterprise environment variables — needed for GHEC/GHES Copilot authentication
     if (process.env.GITHUB_SERVER_URL) environment.GITHUB_SERVER_URL = process.env.GITHUB_SERVER_URL;


### PR DESCRIPTION
## Summary
- Ties color behavior to the existing `--tty` CLI flag: when set, uses `FORCE_COLOR=1`, `TERM=xterm-256color`, `COLUMNS=120` instead of unconditional `NO_COLOR=1`
- Prevents host `TERM` from overriding the explicit `xterm-256color` when `--tty` is active
- Adds tests for both tty and non-tty color environment behavior

Closes #1427

## Test plan
- [x] All 1288 unit tests pass
- [x] Lint passes (0 errors)
- [ ] Verify `awf --tty --allow-domains example.com 'env | grep -E "FORCE_COLOR|TERM|COLUMNS|NO_COLOR"'` shows correct env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)