### PR TITLE
fix: ensure labels exist before creating regression issues

### DIFF
--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -88,6 +88,28 @@ jobs:
             "| \($r.metric) | \($r.mean)\($r.unit) | \($r.median)\($r.unit) | \($r.p95)\($r.unit) | \($r.p99)\($r.unit) | \($t.target // "N/A")\(if $t then $r.unit else "" end) | \($t.critical // "N/A")\(if $t then $r.unit else "" end) |"' \
             benchmark-results.json >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Ensure labels exist
+        if: steps.check.outputs.regression_count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'needs-investigation', color: 'e4e669', description: 'Requires further investigation' },
+              { name: 'performance', color: 'd4c5f9', description: 'Performance related' },
+            ];
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, ...label });
+                core.info(`Created label: ${label.name}`);
+              } catch (e) {
+                if (e.status === 422) {
+                  core.info(`Label already exists: ${label.name}`);
+                } else {
+                  throw e;
+                }
+              }
+            }
+
       - name: Create regression issue
         if: steps.check.outputs.regression_count != '0'
         uses: actions/github-script@v7
@@ -123,10 +145,15 @@ jobs:
               `</details>`,
             ].join('\n');
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Performance regression detected (${new Date().toISOString().split('T')[0]})`,
-              body,
-              labels: ['performance', 'needs-investigation'],
-            });
+            try {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Performance regression detected (${new Date().toISOString().split('T')[0]})`,
+                body,
+                labels: ['performance', 'needs-investigation'],
+              });
+              core.info(`Created regression issue: ${issue.data.html_url}`);
+            } catch (error) {
+              core.setFailed(`Failed to create regression issue: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- Add an "Ensure labels exist" step before issue creation that creates `needs-investigation` and `performance` labels if they don't already exist, preventing API 422 errors
- Add try/catch error handling around the issue creation step so failures are surfaced via `core.setFailed()` instead of silently failing

## Test plan
- [ ] Verify YAML is valid (validated locally with Python yaml parser)
- [ ] Trigger workflow manually to confirm label creation and issue creation work end-to-end

Fixes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)