### PR TITLE
fix: guard null execSync return in benchmark exec helper

### DIFF
--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -64,6 +64,10 @@ jobs:
 
       - name: Validate benchmark JSON
         run: |
+          if [ ! -s benchmark-results.json ]; then
+            echo "ERROR: benchmark-results.json is empty"
+            exit 1
+          fi
           if ! jq empty benchmark-results.json 2>/dev/null; then
             echo "ERROR: benchmark-results.json is not valid JSON"
             cat benchmark-results.json

--- a/scripts/ci/benchmark-performance.ts
+++ b/scripts/ci/benchmark-performance.ts
@@ -56,7 +56,7 @@ const THRESHOLDS: Record<string, { target: number; critical: number }> = {
 // ── Helpers ────────────────────────────────────────────────────────
 
 function exec(cmd: string, opts?: ExecSyncOptions): string {
-  return execSync(cmd, { encoding: "utf-8", timeout: 120_000, ...opts }).trim();
+  return (execSync(cmd, { encoding: "utf-8", timeout: 120_000, ...opts }) ?? "").trim();
 }
 
 function timeMs(fn: () => void): number {


### PR DESCRIPTION
## Summary

- Guard against `null` return from `execSync` when called with `{ stdio: "ignore" }` in the benchmark script's `exec()` helper. Without this, `.trim()` crashes with `TypeError: Cannot read properties of null (reading 'trim')`, breaking the entire performance-monitor workflow on the first benchmark.
- Improve JSON validation in `performance-monitor.yml` to reject empty files (the previous `jq empty` check silently passed on empty input).

## Details

When `execSync` is called with `{ stdio: "ignore" }`, it returns `null` instead of a string. The `exec()` helper at line 58 of `benchmark-performance.ts` calls `.trim()` on the return value unconditionally, causing a crash. This affects `benchmarkNetworkCreation()` (line 311) and several other callers that pass `{ stdio: "ignore" }`.

The fix uses nullish coalescing (`?? ""`) to default to an empty string before calling `.trim()`.

Additionally, the `Validate benchmark JSON` step in the workflow used `jq empty` which succeeds on empty files. Added a `[ ! -s ... ]` check to catch this case.

Discovered during end-to-end validation of the benchmark system.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (1341 tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)