### PR TITLE
fix: validate AWF_BENCHMARK_ITERATIONS env var input

### DIFF
--- a/scripts/ci/benchmark-performance.ts
+++ b/scripts/ci/benchmark-performance.ts
@@ -20,7 +20,26 @@ import { stats, parseMb, checkRegressions, BenchmarkResult, BenchmarkReport } fr
 
 // ── Configuration ──────────────────────────────────────────────────
 
-const ITERATIONS = parseInt(process.env.AWF_BENCHMARK_ITERATIONS || '30', 10);
+const DEFAULT_ITERATIONS = 30;
+
+function getIterations(): number {
+  const raw = process.env.AWF_BENCHMARK_ITERATIONS;
+  if (raw === undefined) {
+    return DEFAULT_ITERATIONS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.error(
+      `Invalid AWF_BENCHMARK_ITERATIONS=${JSON.stringify(raw)}; using default ${DEFAULT_ITERATIONS}.`
+    );
+    return DEFAULT_ITERATIONS;
+  }
+
+  return parsed;
+}
+
+const ITERATIONS = getIterations();
 const AWF_CMD = "sudo awf --build-local";
 const ALLOWED_DOMAIN = "api.github.com";
 const CLEANUP_CMD = "sudo docker compose down -v 2>/dev/null; sudo docker rm -f awf-squid awf-agent awf-iptables-init 2>/dev/null; sudo docker network prune -f 2>/dev/null";


### PR DESCRIPTION
## Summary
- Validates `AWF_BENCHMARK_ITERATIONS` env var to ensure it's a positive integer
- Falls back to the default (30) with a clear stderr warning when the input is invalid (NaN or <= 0)
- Prevents `stats()` from throwing on empty `values` array if iterations is 0 or negative

Follow-up to #1870, addressing [Copilot review feedback](https://github.com/github/gh-aw-firewall/pull/1870#discussion_r3061101245).

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)