### PR TITLE
feat: add historical benchmark storage and trend reporting

### DIFF
--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: "30"
 
+concurrency:
+  group: performance-benchmark
+  cancel-in-progress: false  # Let the running benchmark finish; queue the next one
+
 permissions:
   contents: write  # Required to push to benchmark-data branch
   issues: write
@@ -52,6 +56,11 @@ jobs:
           if git fetch origin benchmark-data 2>/dev/null; then
             git show origin/benchmark-data:benchmarks/history.json > benchmarks/history.json 2>/dev/null || echo '[]' > benchmarks/history.json
           else
+            echo '[]' > benchmarks/history.json
+          fi
+          # Validate JSON; fall back to empty array if corrupted
+          if ! jq empty benchmarks/history.json 2>/dev/null; then
+            echo "WARNING: history.json is corrupted, resetting to empty"
             echo '[]' > benchmarks/history.json
           fi
           echo "History entries: $(jq 'length' benchmarks/history.json)"

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -12,7 +12,7 @@ on:
         default: "30"
 
 permissions:
-  contents: read
+  contents: write  # Required to push to benchmark-data branch
   issues: write
 
 jobs:
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -43,6 +45,16 @@ jobs:
           exec node "${{ github.workspace }}/dist/cli.js" "$@"
           WRAPPER
           sudo chmod +x /usr/local/bin/awf
+
+      - name: Fetch benchmark history
+        run: |
+          mkdir -p benchmarks
+          if git fetch origin benchmark-data 2>/dev/null; then
+            git show origin/benchmark-data:benchmarks/history.json > benchmarks/history.json 2>/dev/null || echo '[]' > benchmarks/history.json
+          else
+            echo '[]' > benchmarks/history.json
+          fi
+          echo "History entries: $(jq 'length' benchmarks/history.json)"
 
       - name: Run benchmarks
         id: benchmark
@@ -75,6 +87,50 @@ jobs:
             cat benchmark-results.json
             exit 1
           fi
+
+      - name: Append to benchmark history
+        run: |
+          HISTORY_FILE="benchmarks/history.json"
+          if ! jq -e '.results' benchmark-results.json > /dev/null 2>&1; then
+            echo "Invalid or missing benchmark results — skipping history update"
+            exit 0
+          fi
+          ENTRY=$(jq '{timestamp, commitSha, iterations, results, regressions}' benchmark-results.json)
+          UPDATED=$(jq --argjson entry "$ENTRY" '. + [$entry]' "$HISTORY_FILE")
+          # Keep only last 50 entries
+          echo "$UPDATED" | jq '.[-50:]' > "$HISTORY_FILE"
+          echo "History now has $(jq 'length' "$HISTORY_FILE") entries"
+
+      - name: Commit benchmark history
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cp benchmarks/history.json /tmp/history.json
+          cp benchmark-results.json /tmp/benchmark-results.json
+          if git fetch origin benchmark-data 2>/dev/null; then
+            git checkout benchmark-data
+          else
+            git checkout --orphan benchmark-data
+            git rm -rf . 2>/dev/null || true
+          fi
+          mkdir -p benchmarks
+          cp /tmp/history.json benchmarks/history.json
+          git add benchmarks/history.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update benchmark history [skip ci]"
+            git push origin benchmark-data
+          fi
+
+      - name: Restore main branch
+        run: |
+          git checkout ${{ github.sha }}
+          cp /tmp/history.json benchmarks/history.json
+          cp /tmp/benchmark-results.json benchmark-results.json
+
+      - name: Generate trend report
+        run: npx tsx scripts/ci/benchmark-trend.ts >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for regressions
         id: check

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs:build": "cd docs-site && npm run build",
     "docs:preview": "cd docs-site && npm run preview",
     "benchmark": "npx tsx scripts/ci/benchmark-performance.ts",
+    "benchmark:trend": "npx tsx scripts/ci/benchmark-trend.ts",
     "build:bundle": "npm run build && node scripts/build-bundle.mjs"
   },
   "keywords": [

--- a/scripts/ci/benchmark-trend.test.ts
+++ b/scripts/ci/benchmark-trend.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for benchmark-trend.ts logic.
+ *
+ * Tests the core functions: delta computation and Markdown formatting.
+ * The script's main() reads from disk and argv, so we test the pure functions directly.
+ */
+
+// Re-implement the pure functions here since the script isn't structured as a library.
+// This mirrors the logic in benchmark-trend.ts without the CLI/file I/O.
+
+interface BenchmarkResult {
+  metric: string;
+  unit: string;
+  values: number[];
+  mean: number;
+  median: number;
+  p95: number;
+  p99: number;
+}
+
+interface HistoryEntry {
+  timestamp: string;
+  commitSha: string;
+  iterations: number;
+  results: BenchmarkResult[];
+  regressions: string[];
+}
+
+interface MetricDelta {
+  metric: string;
+  unit: string;
+  current: number;
+  previous: number;
+  delta: number;
+  deltaPercent: number;
+  regression: boolean;
+}
+
+const REGRESSION_THRESHOLD_PERCENT = 20;
+
+function computeDeltas(current: HistoryEntry, previous: HistoryEntry): MetricDelta[] {
+  const deltas: MetricDelta[] = [];
+  for (const cur of current.results) {
+    const prev = previous.results.find((r) => r.metric === cur.metric);
+    if (!prev) continue;
+    const delta = cur.p95 - prev.p95;
+    const deltaPercent = prev.p95 === 0 ? 0 : (delta / prev.p95) * 100;
+    deltas.push({
+      metric: cur.metric,
+      unit: cur.unit,
+      current: cur.p95,
+      previous: prev.p95,
+      delta,
+      deltaPercent: Math.round(deltaPercent * 10) / 10,
+      regression: deltaPercent > REGRESSION_THRESHOLD_PERCENT,
+    });
+  }
+  return deltas;
+}
+
+function makeEntry(overrides: Partial<HistoryEntry> & { results: BenchmarkResult[] }): HistoryEntry {
+  return {
+    timestamp: "2026-04-09T06:00:00Z",
+    commitSha: "abc1234567890",
+    iterations: 30,
+    regressions: [],
+    ...overrides,
+  };
+}
+
+function makeResult(metric: string, p95: number, unit = "ms"): BenchmarkResult {
+  return { metric, unit, values: [p95], mean: p95, median: p95, p95, p99: p95 };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("computeDeltas", () => {
+  it("computes deltas between two runs", () => {
+    const prev = makeEntry({ results: [makeResult("container_startup_warm", 18000)] });
+    const curr = makeEntry({ results: [makeResult("container_startup_warm", 13000)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].metric).toBe("container_startup_warm");
+    expect(deltas[0].previous).toBe(18000);
+    expect(deltas[0].current).toBe(13000);
+    expect(deltas[0].delta).toBe(-5000);
+    expect(deltas[0].deltaPercent).toBe(-27.8);
+    expect(deltas[0].regression).toBe(false);
+  });
+
+  it("flags regression when delta exceeds 20%", () => {
+    const prev = makeEntry({ results: [makeResult("container_startup_warm", 10000)] });
+    const curr = makeEntry({ results: [makeResult("container_startup_warm", 13000)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas[0].deltaPercent).toBe(30);
+    expect(deltas[0].regression).toBe(true);
+  });
+
+  it("does not flag regression at exactly 20%", () => {
+    const prev = makeEntry({ results: [makeResult("container_startup_warm", 10000)] });
+    const curr = makeEntry({ results: [makeResult("container_startup_warm", 12000)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas[0].deltaPercent).toBe(20);
+    expect(deltas[0].regression).toBe(false);
+  });
+
+  it("handles multiple metrics", () => {
+    const prev = makeEntry({
+      results: [makeResult("warm", 18000), makeResult("cold", 28000), makeResult("memory", 20, "MB")],
+    });
+    const curr = makeEntry({
+      results: [makeResult("warm", 13000), makeResult("cold", 26000), makeResult("memory", 22, "MB")],
+    });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas).toHaveLength(3);
+    expect(deltas[0].metric).toBe("warm");
+    expect(deltas[1].metric).toBe("cold");
+    expect(deltas[2].metric).toBe("memory");
+  });
+
+  it("skips metrics missing from previous run", () => {
+    const prev = makeEntry({ results: [makeResult("warm", 18000)] });
+    const curr = makeEntry({ results: [makeResult("warm", 13000), makeResult("new_metric", 100)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].metric).toBe("warm");
+  });
+
+  it("handles zero previous value without division error", () => {
+    const prev = makeEntry({ results: [makeResult("latency", 0)] });
+    const curr = makeEntry({ results: [makeResult("latency", 100)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas[0].deltaPercent).toBe(0);
+    expect(deltas[0].regression).toBe(false);
+  });
+
+  it("returns empty array for no matching metrics", () => {
+    const prev = makeEntry({ results: [makeResult("a", 100)] });
+    const curr = makeEntry({ results: [makeResult("b", 200)] });
+    const deltas = computeDeltas(curr, prev);
+
+    expect(deltas).toHaveLength(0);
+  });
+});

--- a/scripts/ci/benchmark-trend.ts
+++ b/scripts/ci/benchmark-trend.ts
@@ -60,7 +60,12 @@ function parseArgs(): { last: number; format: "markdown" | "json" } {
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--last" && args[i + 1]) {
-      last = parseInt(args[i + 1], 10);
+      const parsed = parseInt(args[i + 1], 10);
+      if (Number.isInteger(parsed) && parsed > 0) {
+        last = parsed;
+      } else {
+        console.error(`Warning: invalid --last value "${args[i + 1]}", using default ${DEFAULT_LAST}`);
+      }
       i++;
     } else if (args[i] === "--format" && args[i + 1]) {
       format = args[i + 1] as "markdown" | "json";

--- a/scripts/ci/benchmark-trend.ts
+++ b/scripts/ci/benchmark-trend.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Benchmark trend reporter for AWF (Agentic Workflow Firewall).
+ *
+ * Reads benchmarks/history.json and outputs:
+ *  - Deltas between the latest run and the previous run
+ *  - A Markdown table of the last N runs
+ *
+ * Usage:
+ *   npx tsx scripts/ci/benchmark-trend.ts [--last N] [--format markdown|json]
+ *
+ * Outputs to stdout (append to $GITHUB_STEP_SUMMARY in CI).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+interface BenchmarkResult {
+  metric: string;
+  unit: string;
+  values: number[];
+  mean: number;
+  median: number;
+  p95: number;
+  p99: number;
+}
+
+interface HistoryEntry {
+  timestamp: string;
+  commitSha: string;
+  iterations: number;
+  results: BenchmarkResult[];
+  regressions: string[];
+}
+
+interface MetricDelta {
+  metric: string;
+  unit: string;
+  current: number;
+  previous: number;
+  delta: number;
+  deltaPercent: number;
+  regression: boolean;
+}
+
+// ── Configuration ─────────────────────────────────────────────────
+
+const REGRESSION_THRESHOLD_PERCENT = 20;
+const DEFAULT_LAST = 10;
+const HISTORY_PATH = path.resolve(__dirname, "../../benchmarks/history.json");
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function parseArgs(): { last: number; format: "markdown" | "json" } {
+  const args = process.argv.slice(2);
+  let last = DEFAULT_LAST;
+  let format: "markdown" | "json" = "markdown";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--last" && args[i + 1]) {
+      last = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === "--format" && args[i + 1]) {
+      format = args[i + 1] as "markdown" | "json";
+      i++;
+    }
+  }
+
+  return { last, format };
+}
+
+function loadHistory(): HistoryEntry[] {
+  if (!fs.existsSync(HISTORY_PATH)) {
+    return [];
+  }
+  try {
+    return JSON.parse(fs.readFileSync(HISTORY_PATH, "utf-8")) as HistoryEntry[];
+  } catch {
+    console.error(`Warning: failed to parse ${HISTORY_PATH}`);
+    return [];
+  }
+}
+
+function computeDeltas(current: HistoryEntry, previous: HistoryEntry): MetricDelta[] {
+  const deltas: MetricDelta[] = [];
+  for (const cur of current.results) {
+    const prev = previous.results.find((r) => r.metric === cur.metric);
+    if (!prev) continue;
+    const delta = cur.p95 - prev.p95;
+    const deltaPercent = prev.p95 === 0 ? 0 : (delta / prev.p95) * 100;
+    deltas.push({
+      metric: cur.metric,
+      unit: cur.unit,
+      current: cur.p95,
+      previous: prev.p95,
+      delta,
+      deltaPercent: Math.round(deltaPercent * 10) / 10,
+      regression: deltaPercent > REGRESSION_THRESHOLD_PERCENT,
+    });
+  }
+  return deltas;
+}
+
+function formatDeltaSign(pct: number): string {
+  if (pct > 0) return `+${pct}%`;
+  if (pct < 0) return `${pct}%`;
+  return "0%";
+}
+
+// ── Formatters ────────────────────────────────────────────────────
+
+function formatMarkdown(history: HistoryEntry[], deltas: MetricDelta[]): string {
+  const lines: string[] = [];
+  lines.push("## Benchmark Trend Report");
+  lines.push("");
+
+  if (history.length === 0) {
+    lines.push("No benchmark history available yet.");
+    return lines.join("\n");
+  }
+
+  // Delta summary
+  if (deltas.length > 0) {
+    lines.push("### Latest vs Previous Run");
+    lines.push("");
+    lines.push("| Metric | Previous (p95) | Current (p95) | Delta | Change |");
+    lines.push("|--------|---------------|--------------|-------|--------|");
+    for (const d of deltas) {
+      const sign = d.delta > 0 ? "+" : "";
+      const warn = d.regression ? " :warning:" : "";
+      lines.push(
+        `| ${d.metric} | ${d.previous}${d.unit} | ${d.current}${d.unit} | ${sign}${d.delta}${d.unit} | ${formatDeltaSign(d.deltaPercent)}${warn} |`
+      );
+    }
+    lines.push("");
+  }
+
+  // Historical table
+  lines.push("### Historical Results (p95)");
+  lines.push("");
+  const metrics = [...new Set(history.flatMap((e) => e.results.map((r) => r.metric)))];
+  lines.push(`| Date | Commit | ${metrics.join(" | ")} |`);
+  lines.push(`|------|--------|${metrics.map(() => "------").join("|")}|`);
+  for (const entry of [...history].reverse()) {
+    const date = entry.timestamp.split("T")[0];
+    const sha = entry.commitSha.substring(0, 7);
+    const values = metrics.map((m) => {
+      const r = entry.results.find((res) => res.metric === m);
+      return r ? `${r.p95}${r.unit}` : "N/A";
+    });
+    lines.push(`| ${date} | ${sha} | ${values.join(" | ")} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+function main(): void {
+  const { last, format } = parseArgs();
+  const history = loadHistory().slice(-last);
+
+  let deltas: MetricDelta[] = [];
+  if (history.length >= 2) {
+    deltas = computeDeltas(history[history.length - 1], history[history.length - 2]);
+  }
+
+  if (format === "json") {
+    console.log(JSON.stringify({ history, deltas }, null, 2));
+  } else {
+    console.log(formatMarkdown(history, deltas));
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds persistent benchmark history and trend reporting to the performance monitoring workflow.

- **Orphan `benchmark-data` branch** stores `benchmarks/history.json` (rolling last 50 entries)
- **Trend report** in GitHub Step Summary shows latest-vs-previous deltas and historical p95 table
- **Workflow steps**: fetch history before benchmarks, append + trim after, commit to orphan branch, generate trend report
- New `scripts/ci/benchmark-trend.ts` script (also runnable locally via `npm run benchmark:trend`)

### How it works

1. Before benchmarks run, fetch `history.json` from the `benchmark-data` orphan branch
2. After benchmarks complete, append the new entry and trim to 50 entries
3. Commit updated history to the orphan branch (separate from main)
4. Generate a trend report showing deltas and historical p95 values in Step Summary

### Example trend output

```
### Latest vs Previous Run
| Metric | Previous (p95) | Current (p95) | Delta | Change |
|--------|---------------|--------------|-------|--------|
| container_startup_warm | 18469ms | 13200ms | -5269ms | -28.5% |
```

## Test plan

- [ ] `npm run build` passes
- [ ] `npx jest benchmark-utils` passes (26 tests)
- [ ] `npm run benchmark:trend` works with empty history (shows "No benchmark history available yet")
- [ ] `npm run benchmark:trend` works with sample data (shows delta table + history table)
- [ ] Workflow dispatch: verify `benchmark-data` branch is created and history is populated

Closes #1866

🤖 Generated with [Claude Code](https://claude.com/claude-code)