### PR TITLE
fix: token analyzers look for wrong artifact name

### DIFF
--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -102,10 +102,10 @@ RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" \
 if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
   echo "No successful runs found for $LOCK_FILE — skipping artifact analysis"
 else
-  # Download artifacts
+  # Download artifacts (firewall-audit-logs contains token-usage.jsonl)
   TMPDIR=$(mktemp -d)
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name agent-artifacts --dir "$TMPDIR" 2>/dev/null || \
+    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || \
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
     --name agent --dir "$TMPDIR" 2>/dev/null
 

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -105,9 +105,9 @@ else
   # Download artifacts (firewall-audit-logs contains token-usage.jsonl)
   TMPDIR=$(mktemp -d)
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || \
+    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || true
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name agent --dir "$TMPDIR" 2>/dev/null
+    --name agent --dir "$TMPDIR" 2>/dev/null || true
 
   # Check token usage
   find "$TMPDIR" -name "token-usage.jsonl" -exec cat {} \;

--- a/.github/workflows/claude-token-usage-analyzer.md
+++ b/.github/workflows/claude-token-usage-analyzer.md
@@ -33,7 +33,7 @@ You are an AI agent that analyzes Claude token usage across agentic workflow run
 
 ## Background
 
-This repository uses the **Agent Workflow Firewall (AWF)** with an api-proxy sidecar that tracks token usage for LLM API calls. Each workflow run with `--enable-api-proxy` produces a `token-usage.jsonl` file captured in the `agent-artifacts` upload artifact.
+This repository uses the **Agent Workflow Firewall (AWF)** with an api-proxy sidecar that tracks token usage for LLM API calls. Each workflow run with `--enable-api-proxy` produces a `token-usage.jsonl` file captured in the `firewall-audit-logs` upload artifact (under `logs/api-proxy-logs/`).
 
 **Token usage tracking is a new feature** — many older runs won't have this data. Handle missing data gracefully.
 
@@ -67,7 +67,7 @@ Use `gh run list` via bash to find completed agentic workflow runs from the past
 - `smoke-claude`
 - `secret-digger-claude`
 - `security-review`, `security-guard`
-- Any other Claude-engine workflow with `agent-artifacts`
+- Any other Claude-engine workflow with `firewall-audit-logs`
 
 **Note:** Copilot-engine and Codex-engine workflows (e.g., `smoke-copilot`, `smoke-chroot`, `smoke-services`, `build-test`, `smoke-codex`, `secret-digger-copilot`) are excluded from this analysis — they are covered by the separate Copilot Token Usage Analyzer.
 
@@ -84,7 +84,7 @@ gh run list --repo "$GITHUB_REPOSITORY" --limit 50 \
 
 ### Step 2: Download and Parse Token Usage Data
 
-For each discovered run, attempt to download the `agent-artifacts` artifact and extract `token-usage.jsonl`.
+For each discovered run, attempt to download the `firewall-audit-logs` artifact and extract `token-usage.jsonl`.
 
 **IMPORTANT:** Always use `gh run download` via bash — this is much faster than using MCP `get_job_logs` and the network is configured to allow artifact blob storage access.
 
@@ -92,10 +92,10 @@ For each discovered run, attempt to download the `agent-artifacts` artifact and 
 # Create temp directory
 TMPDIR=$(mktemp -d)
 
-# Try to download artifacts for a run
-gh run download <RUN_ID> --repo "$GITHUB_REPOSITORY" --name agent-artifacts --dir "$TMPDIR/run-<RUN_ID>" 2>/dev/null
+# Try to download artifacts for a run (firewall-audit-logs is the standard artifact name)
+gh run download <RUN_ID> --repo "$GITHUB_REPOSITORY" --name firewall-audit-logs --dir "$TMPDIR/run-<RUN_ID>" 2>/dev/null
 
-# Look for token-usage.jsonl (may be nested under sandbox/firewall/logs/api-proxy-logs/)
+# Look for token-usage.jsonl (nested under logs/api-proxy-logs/)
 find "$TMPDIR/run-<RUN_ID>" -name "token-usage.jsonl" 2>/dev/null
 ```
 

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -104,9 +104,9 @@ else
   # Download artifacts (firewall-audit-logs contains token-usage.jsonl)
   TMPDIR=$(mktemp -d)
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || \
+    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || true
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name agent --dir "$TMPDIR" 2>/dev/null
+    --name agent --dir "$TMPDIR" 2>/dev/null || true
 
   # Check token usage
   find "$TMPDIR" -name "token-usage.jsonl" -exec cat {} \;

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -101,10 +101,10 @@ RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" \
 if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
   echo "No successful runs found for $LOCK_FILE — skipping artifact analysis"
 else
-  # Download artifacts
+  # Download artifacts (firewall-audit-logs contains token-usage.jsonl)
   TMPDIR=$(mktemp -d)
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
-    --name agent-artifacts --dir "$TMPDIR" 2>/dev/null || \
+    --name firewall-audit-logs --dir "$TMPDIR" 2>/dev/null || \
   gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
     --name agent --dir "$TMPDIR" 2>/dev/null
 

--- a/.github/workflows/copilot-token-usage-analyzer.md
+++ b/.github/workflows/copilot-token-usage-analyzer.md
@@ -33,7 +33,7 @@ You are an AI agent that analyzes Copilot token usage across agentic workflow ru
 
 ## Background
 
-This repository uses the **Agent Workflow Firewall (AWF)** with an api-proxy sidecar that tracks token usage for LLM API calls. Each workflow run with `--enable-api-proxy` produces a `token-usage.jsonl` file captured in the `agent-artifacts` upload artifact.
+This repository uses the **Agent Workflow Firewall (AWF)** with an api-proxy sidecar that tracks token usage for LLM API calls. Each workflow run with `--enable-api-proxy` produces a `token-usage.jsonl` file captured in the `firewall-audit-logs` upload artifact (under `logs/api-proxy-logs/`).
 
 **Token usage tracking is a new feature** — many older runs won't have this data. Handle missing data gracefully.
 
@@ -68,7 +68,7 @@ Use `gh run list` via bash to find completed agentic workflow runs from the past
 - `build-test`, `ci-doctor`, `plan`
 - `secret-digger-copilot`
 - `cli-flag-consistency-checker`, `doc-maintainer`
-- Any other Copilot-engine workflow with `agent-artifacts`
+- Any other Copilot-engine workflow with `firewall-audit-logs`
 
 **Note:** Claude-engine and Codex-engine workflows (e.g., `smoke-claude`, `smoke-codex`, `secret-digger-claude`, `secret-digger-codex`, `security-review`, `security-guard`) are excluded from this analysis to limit scope and keep within the time budget.
 
@@ -85,7 +85,7 @@ gh run list --repo "$GITHUB_REPOSITORY" --limit 50 \
 
 ### Step 2: Download and Parse Token Usage Data
 
-For each discovered run, attempt to download the `agent-artifacts` artifact and extract `token-usage.jsonl`.
+For each discovered run, attempt to download the `firewall-audit-logs` artifact and extract `token-usage.jsonl`.
 
 **IMPORTANT:** Always use `gh run download` via bash — this is much faster than using MCP `get_job_logs` and the network is configured to allow artifact blob storage access.
 
@@ -93,10 +93,10 @@ For each discovered run, attempt to download the `agent-artifacts` artifact and 
 # Create temp directory
 TMPDIR=$(mktemp -d)
 
-# Try to download artifacts for a run
-gh run download <RUN_ID> --repo "$GITHUB_REPOSITORY" --name agent-artifacts --dir "$TMPDIR/run-<RUN_ID>" 2>/dev/null
+# Try to download artifacts for a run (firewall-audit-logs is the standard artifact name)
+gh run download <RUN_ID> --repo "$GITHUB_REPOSITORY" --name firewall-audit-logs --dir "$TMPDIR/run-<RUN_ID>" 2>/dev/null
 
-# Look for token-usage.jsonl (may be nested under sandbox/firewall/logs/api-proxy-logs/)
+# Look for token-usage.jsonl (nested under logs/api-proxy-logs/)
 find "$TMPDIR/run-<RUN_ID>" -name "token-usage.jsonl" 2>/dev/null
 ```
 


### PR DESCRIPTION
## Problem

The token usage analyzer and optimizer workflows were downloading `agent-artifacts` to find `token-usage.jsonl`, but the actual artifact uploaded by all AWF workflows is `firewall-audit-logs`. The token data lives at `logs/api-proxy-logs/token-usage.jsonl` inside that artifact.

This caused the daily reports to claim 'no token data' for workflows like Smoke Copilot, even though the data was present and accessible.

## Fix

Updated all 4 token analysis workflows to download `firewall-audit-logs` instead of `agent-artifacts`:
- `copilot-token-usage-analyzer.md`
- `claude-token-usage-analyzer.md`
- `copilot-token-optimizer.md`
- `claude-token-optimizer.md`

## Impact

Future token usage reports should now correctly capture data from all workflows that use `--enable-api-proxy`, including Smoke Copilot (which has cli-proxy enabled — useful for measuring cli-proxy token efficiency).