### PR TITLE
perf: optimize firewall-issue-dispatcher token usage

### DIFF
--- a/.github/workflows/firewall-issue-dispatcher.lock.yml
+++ b/.github/workflows/firewall-issue-dispatcher.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fbe658c4b749faf8d011f4b59225f200f737faa01e581d66458d8758f15fce3f","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bf9313e17d5025d1c7ac9ca14f66cc941bc7a975f0b5bb2c86706e7e9e306b67","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CROSS_REPO_PAT","GH_AW_GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -152,14 +152,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_862c71d87f7960f1_EOF'
+          cat << 'GH_AW_PROMPT_912989fcf22b4269_EOF'
           <system>
-          GH_AW_PROMPT_862c71d87f7960f1_EOF
+          GH_AW_PROMPT_912989fcf22b4269_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_862c71d87f7960f1_EOF'
+          cat << 'GH_AW_PROMPT_912989fcf22b4269_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -191,12 +191,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_862c71d87f7960f1_EOF
+          GH_AW_PROMPT_912989fcf22b4269_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_862c71d87f7960f1_EOF'
+          cat << 'GH_AW_PROMPT_912989fcf22b4269_EOF'
           </system>
           {{#runtime-import .github/workflows/firewall-issue-dispatcher.md}}
-          GH_AW_PROMPT_862c71d87f7960f1_EOF
+          GH_AW_PROMPT_912989fcf22b4269_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -382,9 +382,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7e3ca8e5e4cef6df_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8923c7d9e328c5ff_EOF'
           {"add_comment":{"allowed_repos":["github/gh-aw"],"max":10,"target":"*"},"create_issue":{"labels":["awf-triage"],"max":10},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7e3ca8e5e4cef6df_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8923c7d9e328c5ff_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -600,7 +600,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_52e0e0a9de16c6a3_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5a1f1e4a23e47483_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -626,7 +626,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_52e0e0a9de16c6a3_EOF
+          GH_AW_MCP_CONFIG_5a1f1e4a23e47483_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/firewall-issue-dispatcher.md
+++ b/.github/workflows/firewall-issue-dispatcher.md
@@ -16,7 +16,7 @@ features:
 
 tools:
   github:
-    toolsets: [default]
+    toolsets: [issues]
     allowed-repos: ["github/gh-aw", "github/gh-aw-firewall"]
     min-integrity: none
     github-token: ${{ secrets.GH_AW_CROSS_REPO_PAT }}
@@ -36,58 +36,57 @@ safe-outputs:
 
 # Firewall Issue Dispatcher
 
-You audit open issues in `github/gh-aw` that have the `awf` label and create corresponding tracking issues in `github/gh-aw-firewall` with a detailed problem description and proposed solution.
+You audit open issues in `github/gh-aw` labeled `awf` and create tracking issues in `github/gh-aw-firewall`.
 
-## Step-by-Step Process
+## Step 1: Batch Fetch All Data (ONE command)
 
-### 1. List AWF-Labeled Issues
+Run this single `gh` command to get all open `awf` issues with their comments:
 
-Search for all **open** issues in `github/gh-aw` with the label `awf`.
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "github", name: "gh-aw") {
+      issues(labels: ["awf"], states: [OPEN], first: 50) {
+        nodes {
+          number
+          title
+          body
+          url
+          labels(first: 10) { nodes { name } }
+          comments(first: 100) {
+            nodes { author { login } body }
+          }
+        }
+      }
+    }
+  }
+'
+```
 
-### 2. Filter Out Already-Audited Issues
+## Step 2: Filter Locally
 
-For each issue found, read its comments and check whether any comment contains a link to a `github/gh-aw-firewall` issue (i.e., a URL matching `https://github.com/github/gh-aw-firewall/issues/`). If such a comment exists, **skip** that issue — it has already been audited.
+From the response, filter out issues where **any comment** contains `github.com/github/gh-aw-firewall/issues/`. These are already audited. Do this filtering in your analysis — do NOT make additional API calls.
 
-### 3. Analyze and Create Tracking Issues
+If no unprocessed issues remain, call `noop` and stop.
+
+## Step 3: Create Tracking Issues
 
 For each **unprocessed** issue:
 
-1. **Read the issue thoroughly** — title, body, labels, and all comments — to fully understand the problem.
+1. **Create a tracking issue in `github/gh-aw-firewall`** with:
+   - Title: `[awf] <component>: <summary>`
+   - Body: **Problem**, **Context** (link to original), **Root Cause**, **Proposed Solution**
+   - Reference specific source files. See `AGENTS.md` for component descriptions.
 
-2. **Determine AWF relevance** — identify how this issue relates to the firewall. Consider the AWF architecture:
-   - **Squid proxy** (`src/squid-config.ts`) — domain ACL filtering, HTTP/HTTPS egress control
-   - **Docker orchestration** (`src/docker-manager.ts`) — container lifecycle, environment variable injection, volume mounts
-   - **Agent container** (`containers/agent/entrypoint.sh`) — chroot, iptables, DNS config, capability management
-   - **API proxy sidecar** (`containers/api-proxy/server.js`) — credential injection, GHEC/GHES support
-   - **CLI** (`src/cli.ts`) — flag parsing, configuration, domain allowlisting
-   - **iptables** (`containers/agent/setup-iptables.sh`) — network isolation, port blocking, DNAT rules
-
-3. **Create a new issue in `github/gh-aw-firewall`** with:
-   - A clear, specific title starting with `[awf]` followed by a summary of the AWF-side problem (prefix with the relevant component, e.g., "[awf] agent-container: ..." or "[awf] squid: ...")
-   - A body containing:
-     - **Problem** section: What is broken or missing, from the firewall's perspective
-     - **Context** section: Link to the original `github/gh-aw` issue
-     - **Root Cause** section (if determinable): Which files/components are involved
-     - **Proposed Solution** section: A concrete, actionable fix or investigation path
-   - Use the `create_issue` safe output tool
-
-4. **Comment on the original `github/gh-aw` issue** linking to the newly created tracking issue. Use this format:
-
+2. **Comment on the original `github/gh-aw` issue**:
    > 🔗 AWF tracking issue: https://github.com/github/gh-aw-firewall/issues/NUMBER
 
-   Use the `add_comment` safe output tool with `repo: "github/gh-aw"` and the original issue number.
+## Step 4: Summarize
 
-### 4. Report Results
-
-After processing all issues, summarize what was done:
-- How many `awf`-labeled issues were found
-- How many were skipped (already audited)
-- How many new tracking issues were created
-- If there were no unprocessed issues, report that all `awf`-labeled issues have been audited
+Report: issues found, skipped (already audited), tracking issues created.
 
 ## Guidelines
 
-- **Be specific and actionable** — vague issue descriptions waste engineer time. Reference specific source files and functions.
-- **One tracking issue per gh-aw issue** — do not combine multiple gh-aw issues into a single tracking issue.
-- **Don't duplicate** — if you're unsure whether an issue was already audited, err on the side of skipping.
-- **Propose real solutions** — not just "investigate this." Suggest which code to change and how.
+- **Be specific and actionable** — reference source files and functions.
+- **One tracking issue per gh-aw issue** — do not combine.
+- **Propose real solutions** — not just "investigate this."


### PR DESCRIPTION
## Summary

Optimizes the firewall-issue-dispatcher workflow to reduce token usage and improve reliability.

### Changes

- **Switch toolsets**: `[default]` → `[issues]` — removes ~16 unused MCP tools from agent context
- **Use cli-proxy with GraphQL batch fetch** — single `gh api graphql` call fetches all issues + comments at once, replacing sequential MCP `list_issues` + `get_issue_comments` calls that consumed multiple agent turns
- **Trim prompt** — removed verbose architecture section (agent can read `AGENTS.md` if needed), streamlined instructions from ~80 lines to ~50 lines
- **Explicit batch-then-filter workflow** — agent fetches all data in one turn, filters locally, then creates outputs. Eliminates back-and-forth discovery turns.

### Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| MCP tools in context | ~22 (default) | ~6 (issues) |
| Discovery turns | 3-5 (list → filter → view each) | 1 (single GraphQL batch) |
| Prompt tokens | ~80 lines | ~50 lines |
| Architecture context | Inline (~20 lines) | On-demand via AGENTS.md |

The workflow had a **75% failure rate** with $12.81 wasted on failed runs (issue #1901). These changes reduce per-run token consumption and minimize the number of turns needed for the discovery phase, which is where most failures occurred.

Closes #1901