### PR TITLE
fix: skip add_labels in build-test on workflow_dispatch

### DIFF
--- a/.github/workflows/build-test.md
+++ b/.github/workflows/build-test.md
@@ -242,7 +242,7 @@ After completing ALL tasks, add a **single comment** to the current pull request
 
 **Overall: X/8 ecosystems passed — PASS/FAIL**
 
-If ALL tests across all ecosystems pass, add the label `build-test` to the pull request.
+If ALL tests across all ecosystems pass **and** this run was triggered by a pull request (not `workflow_dispatch`), add the label `build-test` to the pull request.
 If ANY test fails, report the failure with error details below the table.
 
 ## Error Handling


### PR DESCRIPTION
## Problem

The Build Test Suite workflow fails when triggered via `workflow_dispatch` because the agent calls `add_labels` to add the `build-test` label, but there's no PR context available.

**Failed run:** https://github.com/github/gh-aw-firewall/actions/runs/24287513522

The `safe_outputs` job errors with:
```
✗ Message 2 (add_labels) failed: No issue/PR number available
```

Note: `add_comment` gracefully skips when there's no PR context (`Target is "triggering" but not running in issue or pull request context, skipping add_comment`), but `add_labels` does not — it fails the entire run.

## Fix

Update the prompt to instruct the agent to only add the `build-test` label when running in a `pull_request` context, not on `workflow_dispatch`.

## Testing

The agent job itself succeeded — only the `safe_outputs` processing step failed. This prompt change prevents the agent from emitting the `add_labels` output when there's no target PR.