### PR TITLE
fix: correct expression quoting in release.yml containers list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,11 +511,11 @@ jobs:
         run: |
           mkdir -p release
           printf '%s\n' \
-            'ghcr.io/${{ github.repository }}/squid@${{ needs[''build-squid''].outputs.digest }}' \
-            'ghcr.io/${{ github.repository }}/agent@${{ needs[''build-agent''].outputs.digest }}' \
-            'ghcr.io/${{ github.repository }}/agent-act@${{ needs[''build-agent-act''].outputs.digest }}' \
-            'ghcr.io/${{ github.repository }}/api-proxy@${{ needs[''build-api-proxy''].outputs.digest }}' \
-            'ghcr.io/${{ github.repository }}/cli-proxy@${{ needs[''build-cli-proxy''].outputs.digest }}' \
+            "ghcr.io/${{ github.repository }}/squid@${{ needs['build-squid'].outputs.digest }}" \
+            "ghcr.io/${{ github.repository }}/agent@${{ needs['build-agent'].outputs.digest }}" \
+            "ghcr.io/${{ github.repository }}/agent-act@${{ needs['build-agent-act'].outputs.digest }}" \
+            "ghcr.io/${{ github.repository }}/api-proxy@${{ needs['build-api-proxy'].outputs.digest }}" \
+            "ghcr.io/${{ github.repository }}/cli-proxy@${{ needs['build-cli-proxy'].outputs.digest }}" \
             > release/containers.txt
           echo "Generated containers.txt:"
           cat release/containers.txt


### PR DESCRIPTION
## Problem

`release.yml` line 514-518 uses doubled single quotes inside a YAML literal block (`|`):

```yaml
needs[''build-squid''].outputs.digest
```

In a literal block, YAML performs no quote escaping, so `''` is passed verbatim to the GitHub Actions expression evaluator, producing:

> Unexpected symbol: `'build-squid'`'' at position 9

## Fix

Switch the shell `printf` arguments from single-quoted to double-quoted strings. This lets the single quotes inside `${{ needs['build-squid'].outputs.digest }}` pass through correctly to the expression evaluator.

## Impact

This affects the **Generate containers list** step in the release workflow, which builds `containers.txt` for SBOM/provenance attestation.