### PR TITLE
fix: add size-based filtering to --env-all to prevent E2BIG

### DIFF
--- a/src/docker-manager.test.ts
+++ b/src/docker-manager.test.ts
@@ -1645,6 +1645,42 @@ describe('docker-manager', () => {
       }
     });
 
+    it('should skip env vars exceeding MAX_ENV_VALUE_SIZE from env-all passthrough', () => {
+      const largeVarName = 'AWF_TEST_OVERSIZED_VAR';
+      const saved = process.env[largeVarName];
+      // Create a value larger than 64KB
+      process.env[largeVarName] = 'x'.repeat(65 * 1024);
+
+      try {
+        const configWithEnvAll = { ...mockConfig, envAll: true };
+        const result = generateDockerCompose(configWithEnvAll, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        // Oversized var should be skipped
+        expect(env[largeVarName]).toBeUndefined();
+      } finally {
+        if (saved !== undefined) process.env[largeVarName] = saved;
+        else delete process.env[largeVarName];
+      }
+    });
+
+    it('should pass env vars under MAX_ENV_VALUE_SIZE from env-all passthrough', () => {
+      const normalVarName = 'AWF_TEST_NORMAL_VAR';
+      const saved = process.env[normalVarName];
+      process.env[normalVarName] = 'normal_value';
+
+      try {
+        const configWithEnvAll = { ...mockConfig, envAll: true };
+        const result = generateDockerCompose(configWithEnvAll, mockNetworkConfig);
+        const env = result.services.agent.environment as Record<string, string>;
+
+        expect(env[normalVarName]).toBe('normal_value');
+      } finally {
+        if (saved !== undefined) process.env[normalVarName] = saved;
+        else delete process.env[normalVarName];
+      }
+    });
+
     it('should auto-inject GH_HOST from GITHUB_SERVER_URL when envAll is true', () => {
       const prevServerUrl = process.env.GITHUB_SERVER_URL;
       const prevGhHost = process.env.GH_HOST;

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -25,6 +25,19 @@ const DOH_PROXY_CONTAINER_NAME = 'awf-doh-proxy';
 const CLI_PROXY_CONTAINER_NAME = 'awf-cli-proxy';
 
 /**
+ * Maximum size (bytes) of a single environment variable value allowed through
+ * --env-all passthrough. Variables exceeding this are skipped with a warning
+ * to prevent E2BIG errors from ARG_MAX exhaustion.
+ */
+const MAX_ENV_VALUE_SIZE = 64 * 1024; // 64 KB
+
+/**
+ * Total environment size (bytes) threshold for issuing an ARG_MAX warning.
+ * Linux ARG_MAX is ~2 MB for argv + envp combined; warn well before that.
+ */
+const ENV_SIZE_WARNING_THRESHOLD = 1_500_000; // ~1.5 MB
+
+/**
  * Flag set by fastKillAgentContainer() to signal runAgentCommand() that
  * the container was externally stopped. When true, runAgentCommand() skips
  * its own docker wait / log collection to avoid racing with the signal handler.
@@ -794,10 +807,25 @@ export function generateDockerCompose(
 
   // If --env-all is specified, pass through all host environment variables (except excluded ones)
   if (config.envAll) {
+    const skippedLargeVars: string[] = [];
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined && !EXCLUDED_ENV_VARS.has(key) && !Object.prototype.hasOwnProperty.call(environment, key)) {
+        // Skip oversized values to prevent E2BIG (Argument list too long) errors.
+        // The Linux kernel enforces ARG_MAX (~2MB) on argv+envp combined; large env
+        // vars can exhaust this budget, especially when combined with large prompts.
+        if (value.length > MAX_ENV_VALUE_SIZE) {
+          skippedLargeVars.push(`${key} (${(value.length / 1024).toFixed(0)} KB)`);
+          continue;
+        }
         environment[key] = value;
       }
+    }
+    if (skippedLargeVars.length > 0) {
+      logger.warn(`Skipped ${skippedLargeVars.length} oversized env var(s) from --env-all passthrough (>${(MAX_ENV_VALUE_SIZE / 1024).toFixed(0)} KB each):`);
+      for (const entry of skippedLargeVars) {
+        logger.warn(`  - ${entry}`);
+      }
+      logger.warn('Use --env VAR="$VAR" to explicitly pass large values if needed.');
     }
   } else {
     // Default behavior: selectively pass through specific variables
@@ -900,6 +928,21 @@ export function generateDockerCompose(
       environment.no_proxy = environment.NO_PROXY;
     } else if (config.additionalEnv?.no_proxy) {
       environment.NO_PROXY = environment.no_proxy;
+    }
+  }
+
+  // Warn when total environment size approaches ARG_MAX (~2MB).
+  // Linux enforces a combined argv+envp limit; large environments can cause E2BIG errors
+  // when execve() is called inside the container.
+  if (config.envAll) {
+    const totalEnvBytes = Object.entries(environment)
+      .reduce((sum, [k, v]) => sum + k.length + (v?.length ?? 0) + 2, 0); // +2 for '=' and null
+    if (totalEnvBytes > ENV_SIZE_WARNING_THRESHOLD) {
+      logger.warn(
+        `⚠️  Total container environment size is ${(totalEnvBytes / 1024).toFixed(0)} KB — ` +
+        'may cause E2BIG (Argument list too long) errors when combined with large command arguments'
+      );
+      logger.warn('   Consider using --exclude-env to remove unnecessary variables');
     }
   }
 

--- a/src/docker-manager.ts
+++ b/src/docker-manager.ts
@@ -813,8 +813,9 @@ export function generateDockerCompose(
         // Skip oversized values to prevent E2BIG (Argument list too long) errors.
         // The Linux kernel enforces ARG_MAX (~2MB) on argv+envp combined; large env
         // vars can exhaust this budget, especially when combined with large prompts.
-        if (value.length > MAX_ENV_VALUE_SIZE) {
-          skippedLargeVars.push(`${key} (${(value.length / 1024).toFixed(0)} KB)`);
+        const valueSizeBytes = Buffer.byteLength(value, 'utf8');
+        if (valueSizeBytes > MAX_ENV_VALUE_SIZE) {
+          skippedLargeVars.push(`${key} (${(valueSizeBytes / 1024).toFixed(0)} KB)`);
           continue;
         }
         environment[key] = value;


### PR DESCRIPTION
## Summary

Adds size-based filtering to `--env-all` passthrough to prevent `E2BIG` (Argument list too long) kernel errors when the runner environment is too large.

## Problem

On GitHub Actions runners, `--env-all` forwards the full environment (~1.5–2 MB of `GITHUB_*`, tool-cache, matrix vars, etc.) into the container. Combined with large command arguments (e.g., inlined prompts via `--prompt \"$(cat ...)\"`), this exceeds the Linux `ARG_MAX` limit (~2 MB for `argv + envp`), causing:

```
/bin/bash: line 1: /usr/local/bin/node: Argument list too long
```

## Changes

### `src/docker-manager.ts`

**Per-variable size cap (`MAX_ENV_VALUE_SIZE = 64KB`):**
- Variables with values exceeding 64 KB are skipped from `--env-all` passthrough
- Warning lists all skipped variables with their sizes
- Users can still explicitly pass large values via `--env VAR=\"\$VAR\"`

**Total environment size warning (`ENV_SIZE_WARNING_THRESHOLD = 1.5MB`):**
- After all env construction (env-all, env-file, env flags), checks total size
- Warns when approaching ARG_MAX, suggesting `--exclude-env`

### Tests (2 new)
- Oversized var (65KB) correctly skipped from passthrough
- Normal-sized var correctly included in passthrough

## Design Decisions

- **64KB threshold is generous** — most useful env vars are < 1KB; this only catches truly pathological values
- **Warning, not error** — avoids breaking existing workflows; the actual E2BIG failure depends on argv size too
- **No new CLI flag** — sensible defaults first; if users need to override, they can use `--env VAR` explicitly
- **AWF-side mitigation only** — the prompt-side fix (using `--prompt-file` instead of shell expansion) is tracked upstream in gh-aw

Closes #1965